### PR TITLE
Create MotorOutput interface and MotorValues

### DIFF
--- a/src/main/java/frc/lib/motors/MotorOutput.java
+++ b/src/main/java/frc/lib/motors/MotorOutput.java
@@ -1,72 +1,29 @@
 package frc.lib.motors;
 
-import static edu.wpi.first.units.Units.Amps;
-import static edu.wpi.first.units.Units.Rotations;
-import static edu.wpi.first.units.Units.RotationsPerSecond;
-import static edu.wpi.first.units.Units.RotationsPerSecondPerSecond;
-import static edu.wpi.first.units.Units.Volts;
-
-import java.util.function.Supplier;
-
-import com.ctre.phoenix6.controls.ControlRequest;
-
-import edu.wpi.first.units.measure.Angle;
-import edu.wpi.first.units.measure.AngularAcceleration;
-import edu.wpi.first.units.measure.AngularVelocity;
-import edu.wpi.first.units.measure.Current;
 import edu.wpi.first.units.measure.Voltage;
-import frc.lib.configs.MechanismConfig;
 
 /** Simple interface that abstracts motor hardware (allowing us to sent a control request to a motor and get values back, no matter if it's one motor, two motors, or a simulated motor) */
 public interface MotorOutput {
-  
-  //TODO: not sure if it's better to handle values like we did before, with a values class in the subsystem that is changed by the controller, or maybe try something new like this unchangin object of suppliers that gets returned directly from the controller
-  /** Class that provides references to value suppliers from the real or simulated output motor(s) */
-  public static class MotorValues {
-    
-    /** Gets current position */
-    public Supplier<Angle> position = () -> Rotations.of(0.0);
 
-    /** Gets current velocity */
-    public Supplier<AngularVelocity> velocity = () -> RotationsPerSecond.of(0.0);
-
-    /** Gets current acceleration */
-    public Supplier<AngularAcceleration> acceleration = () -> RotationsPerSecondPerSecond.of(0.0);
-
-    /** Gets current armature voltage */
-    public Supplier<Voltage> motorVoltage = () -> Volts.of(0.0);
-
-    /** Gets current supply voltage */
-    public Supplier<Voltage> supplyVoltage = () -> Volts.of(0.0);
-
-    /** Gets current stator current */
-    public Supplier<Current> statorCurrent = () -> Amps.of(0.0);
-
-    /** Gets current supply current */
-    public Supplier<Current> supplyCurrent = () -> Amps.of(0.0);
-
-  }
-
-  //TODO: there is a discussion to be had here, I like the idea of allowing usage of different control requests where applicable, but some different control requests might require some extra configuration, like slot gains for PositionVoltage
+  //TODO: In the future, maybe find a way to allow for other kinds of phoenix specific control requests for things like PositionVoltage for swerve steer motors
   /**
-   * Sets the control request for motor output
+   * Sets the voltage of the motor output
    * 
-   * @param controlRequest new control request
+   * @param voltage new set voltage
    */
-  public void setControl(ControlRequest controlRequest);
+  public void setVoltage(Voltage voltage);
 
   /**
-   * Returns a values class with defined suppliers for different logged motor values
+   * Updates values stored in a MotorValues class
    * 
-   * @return a values class with defined suppliers for different logged motor values
+   * @param values values class to update
    */
-  public MotorValues getValues();
+  public void getUpdatedValues(MotorValues values);
   
   /**
    * Configures motor hardware
    * 
-   * @param config config to configure motor hardware with
    * @return true if configuration was successful
    */
-  public boolean configure(MechanismConfig config);
+  public boolean configure();
 }

--- a/src/main/java/frc/lib/motors/MotorOutput.java
+++ b/src/main/java/frc/lib/motors/MotorOutput.java
@@ -1,0 +1,66 @@
+package frc.lib.motors;
+
+import java.util.function.Supplier;
+
+import com.ctre.phoenix6.controls.ControlRequest;
+
+import edu.wpi.first.units.measure.Angle;
+import edu.wpi.first.units.measure.AngularAcceleration;
+import edu.wpi.first.units.measure.AngularVelocity;
+import edu.wpi.first.units.measure.Current;
+import edu.wpi.first.units.measure.Voltage;
+import frc.lib.configs.MechanismConfig;
+
+/** Simple interface that abstracts motor hardware (allowing us to sent a control request to a motor and get values back, no matter if it's one motor, two motors, or a simulated motor) */
+public interface MotorOutput {
+  
+  //TODO: not sure if it's better to handle values like we did before, with a values class in the subsystem that is changed by the controller, or maybe try something new like this unchangin object of suppliers that gets returned directly from the controller
+  /** Class that provides references to value suppliers from the real or simulated output motor(s) */
+  public static class MotorValues {
+    
+    /** Gets current position */
+    public Supplier<Angle> position;
+
+    /** Gets current velocity */
+    public Supplier<AngularVelocity> velocity;
+
+    /** Gets current acceleration */
+    public Supplier<AngularAcceleration> acceleration;
+
+    /** Gets current armature voltage */
+    public Supplier<Voltage> motorVoltage;
+
+    /** Gets current supply voltage */
+    public Supplier<Voltage> supplyVoltage;
+
+    /** Gets current stator current */
+    public Supplier<Current> statorCurrent;
+
+    /** Gets current supply current */
+    public Supplier<Current> supplyCurrent;
+
+  }
+
+  //TODO: there is a discussion to be had here, I like the idea of allowing usage of different control requests where applicable, but some different control requests might require some extra configuration, like slot gains for PositionVoltage
+  /**
+   * Sets the control request for motor output
+   * 
+   * @param controlRequest new control request
+   */
+  public void setControl(ControlRequest controlRequest);
+
+  /**
+   * Returns a values class with defined suppliers for different logged motor values
+   * 
+   * @return a values class with defined suppliers for different logged motor values
+   */
+  public MotorValues getValues();
+  
+  /**
+   * Configures motor hardware
+   * 
+   * @param config config to configure motor hardware with
+   * @return true if configuration was successful
+   */
+  public boolean configure(MechanismConfig config);
+}

--- a/src/main/java/frc/lib/motors/MotorOutput.java
+++ b/src/main/java/frc/lib/motors/MotorOutput.java
@@ -20,7 +20,7 @@ public interface MotorOutput {
    * @param values values class to update
    * @param dt delta time to allow for sim calculation of values or values that require dt to be calculated
    */
-  public void getUpdatedValues(MotorValues values, Time dt);
+  public void updateValues(MotorValues values, Time dt);
   
   /**
    * Configures motor hardware

--- a/src/main/java/frc/lib/motors/MotorOutput.java
+++ b/src/main/java/frc/lib/motors/MotorOutput.java
@@ -1,5 +1,11 @@
 package frc.lib.motors;
 
+import static edu.wpi.first.units.Units.Amps;
+import static edu.wpi.first.units.Units.Rotations;
+import static edu.wpi.first.units.Units.RotationsPerSecond;
+import static edu.wpi.first.units.Units.RotationsPerSecondPerSecond;
+import static edu.wpi.first.units.Units.Volts;
+
 import java.util.function.Supplier;
 
 import com.ctre.phoenix6.controls.ControlRequest;
@@ -19,25 +25,25 @@ public interface MotorOutput {
   public static class MotorValues {
     
     /** Gets current position */
-    public Supplier<Angle> position;
+    public Supplier<Angle> position = () -> Rotations.of(0.0);
 
     /** Gets current velocity */
-    public Supplier<AngularVelocity> velocity;
+    public Supplier<AngularVelocity> velocity = () -> RotationsPerSecond.of(0.0);
 
     /** Gets current acceleration */
-    public Supplier<AngularAcceleration> acceleration;
+    public Supplier<AngularAcceleration> acceleration = () -> RotationsPerSecondPerSecond.of(0.0);
 
     /** Gets current armature voltage */
-    public Supplier<Voltage> motorVoltage;
+    public Supplier<Voltage> motorVoltage = () -> Volts.of(0.0);
 
     /** Gets current supply voltage */
-    public Supplier<Voltage> supplyVoltage;
+    public Supplier<Voltage> supplyVoltage = () -> Volts.of(0.0);
 
     /** Gets current stator current */
-    public Supplier<Current> statorCurrent;
+    public Supplier<Current> statorCurrent = () -> Amps.of(0.0);
 
     /** Gets current supply current */
-    public Supplier<Current> supplyCurrent;
+    public Supplier<Current> supplyCurrent = () -> Amps.of(0.0);
 
   }
 

--- a/src/main/java/frc/lib/motors/MotorOutput.java
+++ b/src/main/java/frc/lib/motors/MotorOutput.java
@@ -1,5 +1,6 @@
 package frc.lib.motors;
 
+import edu.wpi.first.units.measure.Time;
 import edu.wpi.first.units.measure.Voltage;
 
 /** Simple interface that abstracts motor hardware (allowing us to sent a control request to a motor and get values back, no matter if it's one motor, two motors, or a simulated motor) */
@@ -14,11 +15,12 @@ public interface MotorOutput {
   public void setVoltage(Voltage voltage);
 
   /**
-   * Updates values stored in a MotorValues class
+   * Updates values stored in a MotorValues class and updates sim (if there is a sim)
    * 
    * @param values values class to update
+   * @param dt delta time to allow for sim calculation of values or values that require dt to be calculated
    */
-  public void getUpdatedValues(MotorValues values);
+  public void getUpdatedValues(MotorValues values, Time dt);
   
   /**
    * Configures motor hardware

--- a/src/main/java/frc/lib/motors/MotorOutputFlywheelSim.java
+++ b/src/main/java/frc/lib/motors/MotorOutputFlywheelSim.java
@@ -26,9 +26,6 @@ public class MotorOutputFlywheelSim implements MotorOutput{
   /** Flywheel simulation */
   private final FlywheelSim sim;
 
-  /** System plant */
-  private final LinearSystem<N1, N1, N1> plant;
-
   /** DC motor sim */
   private final DCMotor motor;
 
@@ -57,19 +54,28 @@ public class MotorOutputFlywheelSim implements MotorOutput{
       
     // Set up sim
     this.motor = motor;
-    plant = LinearSystemId.createFlywheelSystem(motor, moi.in(KilogramSquareMeters), config.rotorToSensorRatio()*config.sensorToMechRatio());
+    LinearSystem<N1, N1, N1> plant = LinearSystemId.createFlywheelSystem(motor, moi.in(KilogramSquareMeters), config.rotorToSensorRatio()*config.sensorToMechRatio());
     sim = new FlywheelSim(plant, motor);
     this.kS = kS;
   }
 
   @Override
   public void setVoltage(Voltage voltage) {
-    double volts = voltage.in(Volts);
-    sim.setInputVoltage(volts - Math.copySign(MathUtil.clamp(Math.abs(volts), 0, kS), volts));
+    sim.setInputVoltage(calculateEffectiveVoltage(voltage.in(Volts)));
+  }
+
+  /**
+   * Calculates effective voltage applied to sim (voltage will stay locked at zero until voltage applied by setVoltage is greater than magnitude kS)
+   * 
+   * @param voltage voltage applied by setVoltage
+   * @return effective voltage applied to sim
+   */
+  private double calculateEffectiveVoltage(double voltage) {
+    return voltage - Math.copySign(MathUtil.clamp(Math.abs(voltage), 0, kS), voltage);
   }
 
   @Override
-  public void getUpdatedValues(MotorValues values, Time dt) {
+  public void updateValues(MotorValues values, Time dt) {
     sim.update(dt.in(Seconds));
     position = position.plus(sim.getAngularVelocity().times(dt));
 

--- a/src/main/java/frc/lib/motors/MotorOutputFlywheelSim.java
+++ b/src/main/java/frc/lib/motors/MotorOutputFlywheelSim.java
@@ -1,0 +1,89 @@
+package frc.lib.motors;
+
+import static edu.wpi.first.units.Units.Amps;
+import static edu.wpi.first.units.Units.KilogramSquareMeters;
+import static edu.wpi.first.units.Units.Seconds;
+import static edu.wpi.first.units.Units.Volts;
+
+import edu.wpi.first.math.MathUtil;
+import edu.wpi.first.math.numbers.N1;
+import edu.wpi.first.math.system.LinearSystem;
+import edu.wpi.first.math.system.plant.DCMotor;
+import edu.wpi.first.math.system.plant.LinearSystemId;
+import edu.wpi.first.units.measure.Angle;
+import edu.wpi.first.units.measure.MomentOfInertia;
+import edu.wpi.first.units.measure.Time;
+import edu.wpi.first.units.measure.Voltage;
+import edu.wpi.first.wpilibj.simulation.FlywheelSim;
+import frc.lib.configs.MotorConfig;
+
+/** Motor output implementation for a simulated flywheel */
+public class MotorOutputFlywheelSim implements MotorOutput{
+
+  /** Motor config used for configuration and some constants */
+  private final MotorConfig config;
+  
+  /** Flywheel simulation */
+  private final FlywheelSim sim;
+
+  /** System plant */
+  private final LinearSystem<N1, N1, N1> plant;
+
+  /** DC motor sim */
+  private final DCMotor motor;
+
+  /** Position of flywhell (found by integrating sim velocity) */
+  private Angle position;
+
+  /** Voltage to overcome static friction */
+  private final double kS;
+
+  /**
+   * Motor output with flywheel simulation constructor
+   * 
+   * @param config motor config
+   * @param motor DC motor sim
+   * @param moi moment of inertia of flywheel
+   * @param kS voltage to overcome static friction
+   */
+  public MotorOutputFlywheelSim(
+      MotorConfig config,
+      DCMotor motor,
+      MomentOfInertia moi,
+      double kS) {
+
+    // Set config
+    this.config = config;
+      
+    // Set up sim
+    this.motor = motor;
+    plant = LinearSystemId.createFlywheelSystem(motor, moi.in(KilogramSquareMeters), config.rotorToSensorRatio()*config.sensorToMechRatio());
+    sim = new FlywheelSim(plant, motor);
+    this.kS = kS;
+  }
+
+  @Override
+  public void setVoltage(Voltage voltage) {
+    double volts = voltage.in(Volts);
+    sim.setInputVoltage(volts - Math.copySign(MathUtil.clamp(Math.abs(volts), 0, kS), volts));
+  }
+
+  @Override
+  public void getUpdatedValues(MotorValues values, Time dt) {
+    sim.update(dt.in(Seconds));
+    position = position.plus(sim.getAngularVelocity().times(dt));
+
+    values.position = position;
+    values.velocity = sim.getAngularVelocity();
+    values.acceleration = sim.getAngularAcceleration();
+    values.motorVoltage = Volts.of(sim.getInputVoltage());
+    values.supplyVoltage = Volts.of(sim.getInputVoltage());
+    values.statorCurrent = Amps.of(0.0); //TODO not sure how to actually calculate this
+    values.supplyCurrent = Amps.of(sim.getCurrentDrawAmps()); //TODO not sure if this represents supply or stator current
+  }
+
+  @Override
+  public boolean configure() {
+    return true;
+  }
+}

--- a/src/main/java/frc/lib/motors/MotorOutputTalonFX.java
+++ b/src/main/java/frc/lib/motors/MotorOutputTalonFX.java
@@ -1,0 +1,111 @@
+package frc.lib.motors;
+
+import com.ctre.phoenix6.BaseStatusSignal;
+import com.ctre.phoenix6.StatusSignal;
+import com.ctre.phoenix6.configs.CurrentLimitsConfigs;
+import com.ctre.phoenix6.configs.FeedbackConfigs;
+import com.ctre.phoenix6.configs.MotorOutputConfigs;
+import com.ctre.phoenix6.configs.TalonFXConfiguration;
+import com.ctre.phoenix6.configs.TalonFXConfigurator;
+import com.ctre.phoenix6.controls.VoltageOut;
+import com.ctre.phoenix6.hardware.ParentDevice;
+import com.ctre.phoenix6.hardware.TalonFX;
+import com.ctre.phoenix6.signals.InvertedValue;
+import com.ctre.phoenix6.signals.NeutralModeValue;
+
+import edu.wpi.first.units.measure.Angle;
+import edu.wpi.first.units.measure.AngularAcceleration;
+import edu.wpi.first.units.measure.AngularVelocity;
+import edu.wpi.first.units.measure.Current;
+import edu.wpi.first.units.measure.Voltage;
+import frc.lib.CAN;
+import frc.lib.configs.MotorConfig;
+
+/** Motor output implementation for a single TalonFX controlled motor */
+public class MotorOutputTalonFX implements MotorOutput {
+
+  /** Motor config */
+  private final MotorConfig config;
+
+  /** TalonFX hardware */
+  private final TalonFX motor;
+
+  // Status signals
+  private final StatusSignal<Angle> position;
+  private final StatusSignal<AngularVelocity> velocity;
+  private final StatusSignal<AngularAcceleration> acceleration;
+  private final StatusSignal<Voltage> motorVoltage;
+  private final StatusSignal<Voltage> supplyVoltage;
+  private final StatusSignal<Current> statorCurrent;
+  private final StatusSignal<Current> supplyCurrent;
+
+  /** Voltage control request object */
+  private VoltageOut voltage = new VoltageOut(0.0);
+
+  /** 
+   * Motor output constructor
+   * 
+   * @param config motor config used to configure motor
+   * @param motorCAN CAN id and bus for TalonFX motor
+   */
+  public MotorOutputTalonFX(
+      MotorConfig config,
+      CAN motorCAN) {
+    
+    // set config
+    this.config = config;
+
+    // create hardware and status signals
+    motor = new TalonFX(motorCAN.id(), motorCAN.bus());
+
+    position = motor.getPosition();
+    velocity = motor.getVelocity();
+    acceleration = motor.getAcceleration();
+    motorVoltage = motor.getMotorVoltage();
+    supplyVoltage = motor.getSupplyVoltage();
+    statorCurrent = motor.getStatorCurrent();
+    supplyCurrent = motor.getSupplyCurrent();
+
+    BaseStatusSignal.setUpdateFrequencyForAll(100, position, velocity, acceleration, motorVoltage, supplyVoltage, statorCurrent, supplyCurrent);
+    ParentDevice.optimizeBusUtilizationForAll(motor);
+  }
+
+  @Override
+  public void setVoltage(Voltage voltage) {
+    motor.setControl(this.voltage.withOutput(voltage));
+  }
+
+  @Override
+  public void getUpdatedValues(MotorValues values) {
+    BaseStatusSignal.refreshAll(position, velocity, acceleration, motorVoltage, supplyVoltage, statorCurrent, supplyCurrent);
+
+    values.position = position.getValue();
+    values.velocity = velocity.getValue();
+    values.acceleration = acceleration.getValue();
+    values.motorVoltage = motorVoltage.getValue();
+    values.supplyVoltage = supplyVoltage.getValue();
+    values.statorCurrent = statorCurrent.getValue();
+    values.supplyCurrent = supplyCurrent.getValue();
+  }
+
+  @Override
+  public boolean configure() {
+    // TODO Allow failed configurations to return false
+    TalonFXConfigurator motorConfigurator = motor.getConfigurator();
+
+    TalonFXConfiguration motorConfiguration = new TalonFXConfiguration()
+      .withCurrentLimits(new CurrentLimitsConfigs()
+        .withStatorCurrentLimit(config.statorCurrentLimit())
+        .withSupplyCurrentLimit(config.supplyCurrentLimit()))
+      .withMotorOutput(new MotorOutputConfigs()
+        .withInverted(config.ccwPositive() ? InvertedValue.CounterClockwise_Positive : InvertedValue.Clockwise_Positive)
+        .withNeutralMode(config.neutralBrake() ? NeutralModeValue.Brake : NeutralModeValue.Coast))
+      .withFeedback(new FeedbackConfigs()
+        .withRotorToSensorRatio(config.rotorToSensorRatio())
+        .withSensorToMechanismRatio(config.sensorToMechRatio()));
+
+    motorConfigurator.apply(motorConfiguration);
+
+    return true;
+  }
+}

--- a/src/main/java/frc/lib/motors/MotorOutputTalonFX.java
+++ b/src/main/java/frc/lib/motors/MotorOutputTalonFX.java
@@ -77,7 +77,7 @@ public class MotorOutputTalonFX implements MotorOutput {
   }
 
   @Override
-  public void getUpdatedValues(MotorValues values, Time dt) {
+  public void updateValues(MotorValues values, Time dt) {
     BaseStatusSignal.refreshAll(position, velocity, acceleration, motorVoltage, supplyVoltage, statorCurrent, supplyCurrent);
 
     values.position = position.getValue();

--- a/src/main/java/frc/lib/motors/MotorOutputTalonFX.java
+++ b/src/main/java/frc/lib/motors/MotorOutputTalonFX.java
@@ -17,6 +17,7 @@ import edu.wpi.first.units.measure.Angle;
 import edu.wpi.first.units.measure.AngularAcceleration;
 import edu.wpi.first.units.measure.AngularVelocity;
 import edu.wpi.first.units.measure.Current;
+import edu.wpi.first.units.measure.Time;
 import edu.wpi.first.units.measure.Voltage;
 import frc.lib.CAN;
 import frc.lib.configs.MotorConfig;
@@ -76,7 +77,7 @@ public class MotorOutputTalonFX implements MotorOutput {
   }
 
   @Override
-  public void getUpdatedValues(MotorValues values) {
+  public void getUpdatedValues(MotorValues values, Time dt) {
     BaseStatusSignal.refreshAll(position, velocity, acceleration, motorVoltage, supplyVoltage, statorCurrent, supplyCurrent);
 
     values.position = position.getValue();

--- a/src/main/java/frc/lib/motors/MotorOutputTalonFX2.java
+++ b/src/main/java/frc/lib/motors/MotorOutputTalonFX2.java
@@ -1,0 +1,123 @@
+package frc.lib.motors;
+
+import com.ctre.phoenix6.BaseStatusSignal;
+import com.ctre.phoenix6.StatusSignal;
+import com.ctre.phoenix6.configs.CurrentLimitsConfigs;
+import com.ctre.phoenix6.configs.FeedbackConfigs;
+import com.ctre.phoenix6.configs.MotorOutputConfigs;
+import com.ctre.phoenix6.configs.TalonFXConfiguration;
+import com.ctre.phoenix6.configs.TalonFXConfigurator;
+import com.ctre.phoenix6.controls.Follower;
+import com.ctre.phoenix6.controls.VoltageOut;
+import com.ctre.phoenix6.hardware.ParentDevice;
+import com.ctre.phoenix6.hardware.TalonFX;
+import com.ctre.phoenix6.signals.InvertedValue;
+import com.ctre.phoenix6.signals.NeutralModeValue;
+
+import edu.wpi.first.units.measure.Angle;
+import edu.wpi.first.units.measure.AngularAcceleration;
+import edu.wpi.first.units.measure.AngularVelocity;
+import edu.wpi.first.units.measure.Current;
+import edu.wpi.first.units.measure.Voltage;
+import frc.lib.CAN;
+import frc.lib.configs.MotorConfig;
+
+/** Motor output implementation for two TalonFX controlled motors */
+public class MotorOutputTalonFX2 implements MotorOutput {
+
+  /** Motor config */
+  private final MotorConfig config;
+
+  /** Leader motor */
+  private final TalonFX leader;
+
+  /** Follower motor */
+  private final TalonFX follower;
+
+  // Status signals
+  private final StatusSignal<Angle> position;
+  private final StatusSignal<AngularVelocity> velocity;
+  private final StatusSignal<AngularAcceleration> acceleration;
+  private final StatusSignal<Voltage> motorVoltage;
+  private final StatusSignal<Voltage> supplyVoltage;
+  private final StatusSignal<Current> statorCurrent;
+  private final StatusSignal<Current> supplyCurrent;
+
+  /** Voltage control request object */
+  private VoltageOut voltage = new VoltageOut(0.0);
+
+  /** 
+   * Motor output constructor
+   * 
+   * @param config motor config used to configure motor
+   * @param leaderCAN CAN id and bus for leader motor
+   * @param followerCAN CAN id and bus for follower motor
+   */
+  public MotorOutputTalonFX2(
+      MotorConfig config,
+      CAN leaderCAN,
+      CAN followerCAN,
+      boolean invertFollower) {
+    
+    // set config
+    this.config = config;
+
+    // create hardware and status signals
+    leader = new TalonFX(leaderCAN.id(), leaderCAN.bus());
+    follower = new TalonFX(followerCAN.id(), followerCAN.bus());
+
+    follower.setControl(new Follower(leaderCAN.id(), invertFollower));
+
+    position = leader.getPosition();
+    velocity = leader.getVelocity();
+    acceleration = leader.getAcceleration();
+    motorVoltage = leader.getMotorVoltage();
+    supplyVoltage = leader.getSupplyVoltage();
+    statorCurrent = leader.getStatorCurrent();
+    supplyCurrent = leader.getSupplyCurrent();
+
+    BaseStatusSignal.setUpdateFrequencyForAll(100, position, velocity, acceleration, motorVoltage, supplyVoltage, statorCurrent, supplyCurrent);
+    ParentDevice.optimizeBusUtilizationForAll(leader, follower);
+  }
+
+  @Override
+  public void setVoltage(Voltage voltage) {
+    leader.setControl(this.voltage.withOutput(voltage));
+  }
+
+  @Override
+  public void getUpdatedValues(MotorValues values) {
+    BaseStatusSignal.refreshAll(position, velocity, acceleration, motorVoltage, supplyVoltage, statorCurrent, supplyCurrent);
+
+    values.position = position.getValue();
+    values.velocity = velocity.getValue();
+    values.acceleration = acceleration.getValue();
+    values.motorVoltage = motorVoltage.getValue();
+    values.supplyVoltage = supplyVoltage.getValue();
+    values.statorCurrent = statorCurrent.getValue();
+    values.supplyCurrent = supplyCurrent.getValue();
+  }
+
+  @Override
+  public boolean configure() {
+    // TODO Allow failed configurations to return false
+    TalonFXConfigurator leaderConfigurator = leader.getConfigurator();
+    TalonFXConfigurator followerConfigurator = follower.getConfigurator();
+
+    TalonFXConfiguration motorConfiguration = new TalonFXConfiguration()
+      .withCurrentLimits(new CurrentLimitsConfigs()
+        .withStatorCurrentLimit(config.statorCurrentLimit())
+        .withSupplyCurrentLimit(config.supplyCurrentLimit()))
+      .withMotorOutput(new MotorOutputConfigs()
+        .withInverted(config.ccwPositive() ? InvertedValue.CounterClockwise_Positive : InvertedValue.Clockwise_Positive)
+        .withNeutralMode(config.neutralBrake() ? NeutralModeValue.Brake : NeutralModeValue.Coast))
+      .withFeedback(new FeedbackConfigs()
+        .withRotorToSensorRatio(config.rotorToSensorRatio())
+        .withSensorToMechanismRatio(config.sensorToMechRatio()));
+
+    leaderConfigurator.apply(motorConfiguration);
+    followerConfigurator.apply(motorConfiguration);
+
+    return true;
+  }
+}

--- a/src/main/java/frc/lib/motors/MotorOutputTalonFX2.java
+++ b/src/main/java/frc/lib/motors/MotorOutputTalonFX2.java
@@ -18,6 +18,7 @@ import edu.wpi.first.units.measure.Angle;
 import edu.wpi.first.units.measure.AngularAcceleration;
 import edu.wpi.first.units.measure.AngularVelocity;
 import edu.wpi.first.units.measure.Current;
+import edu.wpi.first.units.measure.Time;
 import edu.wpi.first.units.measure.Voltage;
 import frc.lib.CAN;
 import frc.lib.configs.MotorConfig;
@@ -86,7 +87,7 @@ public class MotorOutputTalonFX2 implements MotorOutput {
   }
 
   @Override
-  public void getUpdatedValues(MotorValues values) {
+  public void getUpdatedValues(MotorValues values, Time dt) {
     BaseStatusSignal.refreshAll(position, velocity, acceleration, motorVoltage, supplyVoltage, statorCurrent, supplyCurrent);
 
     values.position = position.getValue();

--- a/src/main/java/frc/lib/motors/MotorOutputTalonFX2.java
+++ b/src/main/java/frc/lib/motors/MotorOutputTalonFX2.java
@@ -87,7 +87,7 @@ public class MotorOutputTalonFX2 implements MotorOutput {
   }
 
   @Override
-  public void getUpdatedValues(MotorValues values, Time dt) {
+  public void updateValues(MotorValues values, Time dt) {
     BaseStatusSignal.refreshAll(position, velocity, acceleration, motorVoltage, supplyVoltage, statorCurrent, supplyCurrent);
 
     values.position = position.getValue();

--- a/src/main/java/frc/lib/motors/MotorValues.java
+++ b/src/main/java/frc/lib/motors/MotorValues.java
@@ -1,0 +1,39 @@
+package frc.lib.motors;
+
+import static edu.wpi.first.units.Units.Amps;
+import static edu.wpi.first.units.Units.Rotations;
+import static edu.wpi.first.units.Units.RotationsPerSecond;
+import static edu.wpi.first.units.Units.RotationsPerSecondPerSecond;
+import static edu.wpi.first.units.Units.Volts;
+
+import edu.wpi.first.units.measure.Angle;
+import edu.wpi.first.units.measure.AngularAcceleration;
+import edu.wpi.first.units.measure.AngularVelocity;
+import edu.wpi.first.units.measure.Current;
+import edu.wpi.first.units.measure.Voltage;
+
+/** Class that contains motor output values */
+public class MotorValues {
+  
+  /** Current position of motor */
+  public Angle position = Rotations.of(0.0);
+
+  /** Current velocity of motor */
+  public AngularVelocity velocity = RotationsPerSecond.of(0.0);
+
+  /** Current acceleration of motor */
+  public AngularAcceleration acceleration = RotationsPerSecondPerSecond.of(0.0);
+
+  /** Current armature voltage  */
+  public Voltage motorVoltage = Volts.of(0.0);
+
+  /** Current supply voltage */
+  public Voltage supplyVoltage = Volts.of(0.0);
+
+  /** Current stator current */
+  public Current statorCurrent = Amps.of(0.0);
+
+  /** Current supply current */
+  public Current supplyCurrent = Amps.of(0.0);
+  
+}


### PR DESCRIPTION
A MotorOutput abstraction that allows for sim, one motor, and two motor outputs to be treated the same, while handling PID, FF, system modeling, and all that stuff within subsystem code

Some stuff I'm not sure on (there's TODOs for them too)

- I thought it'd be interesting to try a new way of returning values from the controller, by returning a values class of suppliers from the controller object, rather than passing a values object from within the subsystem to be changed by the controller, but I'm not sure on that one. I didn't really love the way it was done before, but I'm not sure if this is better or will just cause issues
- I like the idea of inputting ControlRequests to the motor output to allow for taking advantage of different CTR control requests where they're useful, but there is also the issue of some control requests requiring extra configuration to be used correctly, like slot gains and bound sensors for PositionVoltage requests