### PR TITLE
#6 use mutablemeasure for values

### DIFF
--- a/src/main/java/frc/lib/controllers/position/PositionController.java
+++ b/src/main/java/frc/lib/controllers/position/PositionController.java
@@ -7,9 +7,12 @@ import static edu.wpi.first.units.Units.RotationsPerSecondPerSecond;
 import static edu.wpi.first.units.Units.Volts;
 
 import edu.wpi.first.units.measure.Angle;
-import edu.wpi.first.units.measure.AngularAcceleration;
 import edu.wpi.first.units.measure.AngularVelocity;
-import edu.wpi.first.units.measure.Current;
+import edu.wpi.first.units.measure.MutAngle;
+import edu.wpi.first.units.measure.MutAngularAcceleration;
+import edu.wpi.first.units.measure.MutAngularVelocity;
+import edu.wpi.first.units.measure.MutCurrent;
+import edu.wpi.first.units.measure.MutVoltage;
 import edu.wpi.first.units.measure.Voltage;
 
 /** Interface that defines the base io functionality all position controllers will inherit */
@@ -19,22 +22,22 @@ public interface PositionController {
   public static class PositionControllerValues {
 
     /** Motor position */
-    public Angle position = Rotations.of(0.0);
+    public MutAngle position = Rotations.mutable(0.0);
 
     /** Motor velocity */
-    public AngularVelocity velocity = RotationsPerSecond.of(0.0);
+    public MutAngularVelocity velocity = RotationsPerSecond.mutable(0.0);
 
     /** Motor acceleration */
-    public AngularAcceleration acceleration = RotationsPerSecondPerSecond.of(0.0);
+    public MutAngularAcceleration acceleration = RotationsPerSecondPerSecond.mutable(0.0);
 
     /** Motor voltage in volts */
-    public Voltage motorVoltage = Volts.of(0.0);
+    public MutVoltage motorVoltage = Volts.mutable(0.0);
 
     /** Stator current in amps */
-    public Current statorCurrent = Amps.of(0.0);
+    public MutCurrent statorCurrent = Amps.mutable(0.0);
 
     /** Supply current in amps */
-    public Current supplyCurrent = Amps.of(0.0);
+    public MutCurrent supplyCurrent = Amps.mutable(0.0);
 
   }
 

--- a/src/main/java/frc/lib/controllers/position/PositionControllerSim.java
+++ b/src/main/java/frc/lib/controllers/position/PositionControllerSim.java
@@ -32,7 +32,12 @@ public class PositionControllerSim implements PositionController {
   public void getUpdatedVals(PositionControllerValues values) {
     values.position.mut_replace(position);
     values.velocity.mut_replace(velocity);
-    values.motorVoltage.mut_replace((voltageSet) ? setVoltage : Volts.of(0.0));
+    
+    if (voltageSet) {
+      values.motorVoltage.mut_replace(setVoltage);
+    } else {
+      values.motorVoltage.mut_replace(0.0, Volts);
+    }
   }
 
   @Override

--- a/src/main/java/frc/lib/controllers/position/PositionControllerSim.java
+++ b/src/main/java/frc/lib/controllers/position/PositionControllerSim.java
@@ -30,9 +30,9 @@ public class PositionControllerSim implements PositionController {
 
   @Override
   public void getUpdatedVals(PositionControllerValues values) {
-    values.position = position;
-    values.velocity = velocity;
-    values.motorVoltage = (voltageSet) ? setVoltage : Volts.of(0.0);
+    values.position.mut_replace(position);
+    values.velocity.mut_replace(velocity);
+    values.motorVoltage.mut_replace((voltageSet) ? setVoltage : Volts.of(0.0));
   }
 
   @Override

--- a/src/main/java/frc/lib/controllers/position/PositionControllerTalonFXElevator.java
+++ b/src/main/java/frc/lib/controllers/position/PositionControllerTalonFXElevator.java
@@ -140,12 +140,12 @@ public class PositionControllerTalonFXElevator implements PositionController {
   public void getUpdatedVals(PositionControllerValues values) {
     BaseStatusSignal.refreshAll(position, velocity, acceleration, motorVoltage, statorCurrent, supplyCurrent);
 
-    values.position = position.getValue().plus(positionOffset);
-    values.velocity = velocity.getValue();
-    values.acceleration = acceleration.getValue();
-    values.motorVoltage = motorVoltage.getValue();
-    values.statorCurrent = statorCurrent.getValue();
-    values.supplyCurrent = supplyCurrent.getValue();
+    values.position.mut_replace(position.getValue().plus(positionOffset));
+    values.velocity.mut_replace(velocity.getValue());
+    values.acceleration.mut_replace(acceleration.getValue());
+    values.motorVoltage.mut_replace(motorVoltage.getValue());
+    values.statorCurrent.mut_replace(statorCurrent.getValue());
+    values.supplyCurrent.mut_replace(supplyCurrent.getValue());
   }
 
   @Override

--- a/src/main/java/frc/lib/controllers/position/PositionControllerTalonFXElevator.java
+++ b/src/main/java/frc/lib/controllers/position/PositionControllerTalonFXElevator.java
@@ -1,9 +1,11 @@
 package frc.lib.controllers.position;
 
+import static edu.wpi.first.units.Units.Amps;
 import static edu.wpi.first.units.Units.Radians;
 import static edu.wpi.first.units.Units.RadiansPerSecond;
 import static edu.wpi.first.units.Units.Rotations;
 import static edu.wpi.first.units.Units.RotationsPerSecond;
+import static edu.wpi.first.units.Units.RotationsPerSecondPerSecond;
 import static edu.wpi.first.units.Units.Volts;
 
 import com.ctre.phoenix6.BaseStatusSignal;
@@ -140,12 +142,12 @@ public class PositionControllerTalonFXElevator implements PositionController {
   public void getUpdatedVals(PositionControllerValues values) {
     BaseStatusSignal.refreshAll(position, velocity, acceleration, motorVoltage, statorCurrent, supplyCurrent);
 
-    values.position.mut_replace(position.getValue().plus(positionOffset));
-    values.velocity.mut_replace(velocity.getValue());
-    values.acceleration.mut_replace(acceleration.getValue());
-    values.motorVoltage.mut_replace(motorVoltage.getValue());
-    values.statorCurrent.mut_replace(statorCurrent.getValue());
-    values.supplyCurrent.mut_replace(supplyCurrent.getValue());
+    values.position.mut_replace(position.getValueAsDouble(), Rotations).mut_plus(positionOffset);
+    values.velocity.mut_replace(velocity.getValueAsDouble(), RotationsPerSecond);
+    values.acceleration.mut_replace(acceleration.getValueAsDouble(), RotationsPerSecondPerSecond);
+    values.motorVoltage.mut_replace(motorVoltage.getValueAsDouble(), Volts);
+    values.statorCurrent.mut_replace(statorCurrent.getValueAsDouble(), Amps);
+    values.supplyCurrent.mut_replace(supplyCurrent.getValueAsDouble(), Amps);
   }
 
   @Override

--- a/src/main/java/frc/lib/controllers/position/PositionControllerTalonFXEndgame.java
+++ b/src/main/java/frc/lib/controllers/position/PositionControllerTalonFXEndgame.java
@@ -1,8 +1,11 @@
 package frc.lib.controllers.position;
 
+import static edu.wpi.first.units.Units.Amps;
 import static edu.wpi.first.units.Units.Radians;
 import static edu.wpi.first.units.Units.RadiansPerSecond;
 import static edu.wpi.first.units.Units.Rotations;
+import static edu.wpi.first.units.Units.RotationsPerSecond;
+import static edu.wpi.first.units.Units.RotationsPerSecondPerSecond;
 import static edu.wpi.first.units.Units.Volts;
 
 import com.ctre.phoenix6.BaseStatusSignal;
@@ -137,12 +140,12 @@ public class PositionControllerTalonFXEndgame implements PositionController {
   public void getUpdatedVals(PositionControllerValues values) {
     BaseStatusSignal.refreshAll(position, velocity, acceleration, motorVoltage, statorCurrent, supplyCurrent);
 
-    values.position.mut_replace(position.getValue().plus(positionOffset));
-    values.velocity.mut_replace(velocity.getValue());
-    values.acceleration.mut_replace(acceleration.getValue());
-    values.motorVoltage.mut_replace(motorVoltage.getValue());
-    values.statorCurrent.mut_replace(statorCurrent.getValue());
-    values.supplyCurrent.mut_replace(supplyCurrent.getValue());
+    values.position.mut_replace(position.getValueAsDouble(), Rotations).mut_plus(positionOffset);
+    values.velocity.mut_replace(velocity.getValueAsDouble(), RotationsPerSecond);
+    values.acceleration.mut_replace(acceleration.getValueAsDouble(), RotationsPerSecondPerSecond);
+    values.motorVoltage.mut_replace(motorVoltage.getValueAsDouble(), Volts);
+    values.statorCurrent.mut_replace(statorCurrent.getValueAsDouble(), Amps);
+    values.supplyCurrent.mut_replace(supplyCurrent.getValueAsDouble(), Amps);
   }
 
   @Override

--- a/src/main/java/frc/lib/controllers/position/PositionControllerTalonFXEndgame.java
+++ b/src/main/java/frc/lib/controllers/position/PositionControllerTalonFXEndgame.java
@@ -137,12 +137,12 @@ public class PositionControllerTalonFXEndgame implements PositionController {
   public void getUpdatedVals(PositionControllerValues values) {
     BaseStatusSignal.refreshAll(position, velocity, acceleration, motorVoltage, statorCurrent, supplyCurrent);
 
-    values.position = position.getValue().plus(positionOffset);
-    values.velocity = velocity.getValue();
-    values.acceleration = acceleration.getValue();
-    values.motorVoltage = motorVoltage.getValue();
-    values.statorCurrent = statorCurrent.getValue();
-    values.supplyCurrent = supplyCurrent.getValue();
+    values.position.mut_replace(position.getValue().plus(positionOffset));
+    values.velocity.mut_replace(velocity.getValue());
+    values.acceleration.mut_replace(acceleration.getValue());
+    values.motorVoltage.mut_replace(motorVoltage.getValue());
+    values.statorCurrent.mut_replace(statorCurrent.getValue());
+    values.supplyCurrent.mut_replace(supplyCurrent.getValue());
   }
 
   @Override

--- a/src/main/java/frc/lib/controllers/position/PositionControllerTalonFXPivot.java
+++ b/src/main/java/frc/lib/controllers/position/PositionControllerTalonFXPivot.java
@@ -125,12 +125,12 @@ public class PositionControllerTalonFXPivot implements PositionController {
   public void getUpdatedVals(PositionControllerValues values) {
     BaseStatusSignal.refreshAll(position, velocity, acceleration, motorVoltage, statorCurrent, supplyCurrent);
 
-    values.position = position.getValue().plus(positionOffset);
-    values.velocity = velocity.getValue();
-    values.acceleration = acceleration.getValue();
-    values.motorVoltage = motorVoltage.getValue();
-    values.statorCurrent = statorCurrent.getValue();
-    values.supplyCurrent = supplyCurrent.getValue();
+    values.position.mut_replace(position.getValue().plus(positionOffset));
+    values.velocity.mut_replace(velocity.getValue());
+    values.acceleration.mut_replace(acceleration.getValue());
+    values.motorVoltage.mut_replace(motorVoltage.getValue());
+    values.statorCurrent.mut_replace(statorCurrent.getValue());
+    values.supplyCurrent.mut_replace(supplyCurrent.getValue());
   }
 
   @Override

--- a/src/main/java/frc/lib/controllers/position/PositionControllerTalonFXPivot.java
+++ b/src/main/java/frc/lib/controllers/position/PositionControllerTalonFXPivot.java
@@ -1,8 +1,11 @@
 package frc.lib.controllers.position;
 
+import static edu.wpi.first.units.Units.Amps;
 import static edu.wpi.first.units.Units.Radians;
 import static edu.wpi.first.units.Units.RadiansPerSecond;
 import static edu.wpi.first.units.Units.Rotations;
+import static edu.wpi.first.units.Units.RotationsPerSecond;
+import static edu.wpi.first.units.Units.RotationsPerSecondPerSecond;
 import static edu.wpi.first.units.Units.Volts;
 
 import com.ctre.phoenix6.BaseStatusSignal;
@@ -125,12 +128,12 @@ public class PositionControllerTalonFXPivot implements PositionController {
   public void getUpdatedVals(PositionControllerValues values) {
     BaseStatusSignal.refreshAll(position, velocity, acceleration, motorVoltage, statorCurrent, supplyCurrent);
 
-    values.position.mut_replace(position.getValue().plus(positionOffset));
-    values.velocity.mut_replace(velocity.getValue());
-    values.acceleration.mut_replace(acceleration.getValue());
-    values.motorVoltage.mut_replace(motorVoltage.getValue());
-    values.statorCurrent.mut_replace(statorCurrent.getValue());
-    values.supplyCurrent.mut_replace(supplyCurrent.getValue());
+    values.position.mut_replace(position.getValueAsDouble(), Rotations).mut_plus(positionOffset);
+    values.velocity.mut_replace(velocity.getValueAsDouble(), RotationsPerSecond);
+    values.acceleration.mut_replace(acceleration.getValueAsDouble(), RotationsPerSecondPerSecond);
+    values.motorVoltage.mut_replace(motorVoltage.getValueAsDouble(), Volts);
+    values.statorCurrent.mut_replace(statorCurrent.getValueAsDouble(), Amps);
+    values.supplyCurrent.mut_replace(supplyCurrent.getValueAsDouble(), Amps);
   }
 
   @Override

--- a/src/main/java/frc/lib/controllers/position/PositionControllerTalonFXSteer.java
+++ b/src/main/java/frc/lib/controllers/position/PositionControllerTalonFXSteer.java
@@ -1,7 +1,11 @@
 package frc.lib.controllers.position;
 
+import static edu.wpi.first.units.Units.Amps;
 import static edu.wpi.first.units.Units.Radians;
 import static edu.wpi.first.units.Units.Rotations;
+import static edu.wpi.first.units.Units.RotationsPerSecond;
+import static edu.wpi.first.units.Units.RotationsPerSecondPerSecond;
+import static edu.wpi.first.units.Units.Volts;
 
 import com.ctre.phoenix6.BaseStatusSignal;
 import com.ctre.phoenix6.StatusSignal;
@@ -124,12 +128,12 @@ public class PositionControllerTalonFXSteer implements PositionController{
   public void getUpdatedVals(PositionControllerValues values) {
     BaseStatusSignal.refreshAll(position, velocity, acceleration, motorVoltage, statorCurrent, supplyCurrent);
     
-    values.position.mut_replace(position.getValue());
-    values.velocity.mut_replace(velocity.getValue());
-    values.acceleration.mut_replace(acceleration.getValue());
-    values.motorVoltage.mut_replace(motorVoltage.getValue());
-    values.statorCurrent.mut_replace(statorCurrent.getValue());
-    values.supplyCurrent.mut_replace(supplyCurrent.getValue());
+    values.position.mut_replace(position.getValueAsDouble(), Rotations);
+    values.velocity.mut_replace(velocity.getValueAsDouble(), RotationsPerSecond);
+    values.acceleration.mut_replace(acceleration.getValueAsDouble(), RotationsPerSecondPerSecond);
+    values.motorVoltage.mut_replace(motorVoltage.getValueAsDouble(), Volts);
+    values.statorCurrent.mut_replace(statorCurrent.getValueAsDouble(), Amps);
+    values.supplyCurrent.mut_replace(supplyCurrent.getValueAsDouble(), Amps);
   }
 
   public void setPosition(Angle newPos) {

--- a/src/main/java/frc/lib/controllers/position/PositionControllerTalonFXSteer.java
+++ b/src/main/java/frc/lib/controllers/position/PositionControllerTalonFXSteer.java
@@ -124,12 +124,12 @@ public class PositionControllerTalonFXSteer implements PositionController{
   public void getUpdatedVals(PositionControllerValues values) {
     BaseStatusSignal.refreshAll(position, velocity, acceleration, motorVoltage, statorCurrent, supplyCurrent);
     
-    values.position = position.getValue();
-    values.velocity = velocity.getValue();
-    values.acceleration = acceleration.getValue();
-    values.motorVoltage = motorVoltage.getValue();
-    values.statorCurrent = statorCurrent.getValue();
-    values.supplyCurrent = supplyCurrent.getValue();
+    values.position.mut_replace(position.getValue());
+    values.velocity.mut_replace(velocity.getValue());
+    values.acceleration.mut_replace(acceleration.getValue());
+    values.motorVoltage.mut_replace(motorVoltage.getValue());
+    values.statorCurrent.mut_replace(statorCurrent.getValue());
+    values.supplyCurrent.mut_replace(supplyCurrent.getValue());
   }
 
   public void setPosition(Angle newPos) {

--- a/src/main/java/frc/lib/controllers/velocity/VelocityController.java
+++ b/src/main/java/frc/lib/controllers/velocity/VelocityController.java
@@ -6,10 +6,12 @@ import static edu.wpi.first.units.Units.RotationsPerSecond;
 import static edu.wpi.first.units.Units.RotationsPerSecondPerSecond;
 import static edu.wpi.first.units.Units.Volts;
 
-import edu.wpi.first.units.measure.Angle;
-import edu.wpi.first.units.measure.AngularAcceleration;
 import edu.wpi.first.units.measure.AngularVelocity;
-import edu.wpi.first.units.measure.Current;
+import edu.wpi.first.units.measure.MutAngle;
+import edu.wpi.first.units.measure.MutAngularAcceleration;
+import edu.wpi.first.units.measure.MutAngularVelocity;
+import edu.wpi.first.units.measure.MutCurrent;
+import edu.wpi.first.units.measure.MutVoltage;
 import edu.wpi.first.units.measure.Voltage;
 
 /** Interface that defines the base io functionality all velocity controllers will inherit */
@@ -19,22 +21,22 @@ public interface VelocityController {
   public static class VelocityControllerValues {
 
     /** Motor position */
-    public Angle position = Rotations.of(0.0);
+    public MutAngle position = Rotations.mutable(0.0);
 
     /** Motor velocity */
-    public AngularVelocity velocity = RotationsPerSecond.of(0.0);
+    public MutAngularVelocity velocity = RotationsPerSecond.mutable(0.0);
 
     /** Motor acceleration */
-    public AngularAcceleration acceleration = RotationsPerSecondPerSecond.of(0.0);
+    public MutAngularAcceleration acceleration = RotationsPerSecondPerSecond.mutable(0.0);
 
     /** Motor voltage in volts */
-    public Voltage motorVoltage = Volts.of(0.0);
+    public MutVoltage motorVoltage = Volts.mutable(0.0);
 
     /** Stator current in amps */
-    public Current statorCurrent = Amps.of(0.0);
+    public MutCurrent statorCurrent = Amps.mutable(0.0);
 
     /** Supply current in amps */
-    public Current supplyCurrent = Amps.of(0.0);
+    public MutCurrent supplyCurrent = Amps.mutable(0.0);
 
   }
 

--- a/src/main/java/frc/lib/controllers/velocity/VelocityControllerSim.java
+++ b/src/main/java/frc/lib/controllers/velocity/VelocityControllerSim.java
@@ -32,9 +32,9 @@ public class VelocityControllerSim implements VelocityController {
 
   @Override
   public void getUpdatedVals(VelocityControllerValues values) {
-    values.position = position;
-    values.velocity = velocity;
-    values.motorVoltage = (voltageSet) ? setVoltage : Volts.of(0.0);
+    values.position.mut_replace(position);
+    values.velocity.mut_replace(velocity);
+    values.motorVoltage.mut_replace((voltageSet) ? setVoltage : Volts.of(0.0));
   }
 
   @Override

--- a/src/main/java/frc/lib/controllers/velocity/VelocityControllerSim.java
+++ b/src/main/java/frc/lib/controllers/velocity/VelocityControllerSim.java
@@ -34,7 +34,12 @@ public class VelocityControllerSim implements VelocityController {
   public void getUpdatedVals(VelocityControllerValues values) {
     values.position.mut_replace(position);
     values.velocity.mut_replace(velocity);
-    values.motorVoltage.mut_replace((voltageSet) ? setVoltage : Volts.of(0.0));
+    
+    if (voltageSet) {
+      values.motorVoltage.mut_replace(setVoltage);
+    } else {
+      values.motorVoltage.mut_replace(0.0, Volts);
+    }
   }
 
   @Override

--- a/src/main/java/frc/lib/controllers/velocity/VelocityControllerTalonFX.java
+++ b/src/main/java/frc/lib/controllers/velocity/VelocityControllerTalonFX.java
@@ -113,12 +113,12 @@ public class VelocityControllerTalonFX implements VelocityController {
   public void getUpdatedVals(VelocityControllerValues values) {
     BaseStatusSignal.refreshAll(position, velocity, acceleration, motorVoltage, statorCurrent, supplyCurrent);
 
-    values.position = position.getValue();
-    values.velocity = velocity.getValue();
-    values.acceleration = acceleration.getValue();
-    values.motorVoltage = motorVoltage.getValue();
-    values.statorCurrent = statorCurrent.getValue();
-    values.supplyCurrent = supplyCurrent.getValue();
+    values.position.mut_replace(position.getValue());
+    values.velocity.mut_replace(velocity.getValue());
+    values.acceleration.mut_replace(acceleration.getValue());
+    values.motorVoltage.mut_replace(motorVoltage.getValue());
+    values.statorCurrent.mut_replace(statorCurrent.getValue());
+    values.supplyCurrent.mut_replace(supplyCurrent.getValue());
   }
 
   @Override

--- a/src/main/java/frc/lib/motors/MotorOutputFlywheelSim.java
+++ b/src/main/java/frc/lib/motors/MotorOutputFlywheelSim.java
@@ -2,6 +2,7 @@ package frc.lib.motors;
 
 import static edu.wpi.first.units.Units.Amps;
 import static edu.wpi.first.units.Units.KilogramSquareMeters;
+import static edu.wpi.first.units.Units.Rotations;
 import static edu.wpi.first.units.Units.Seconds;
 import static edu.wpi.first.units.Units.Volts;
 
@@ -10,8 +11,8 @@ import edu.wpi.first.math.numbers.N1;
 import edu.wpi.first.math.system.LinearSystem;
 import edu.wpi.first.math.system.plant.DCMotor;
 import edu.wpi.first.math.system.plant.LinearSystemId;
-import edu.wpi.first.units.measure.Angle;
 import edu.wpi.first.units.measure.MomentOfInertia;
+import edu.wpi.first.units.measure.MutAngle;
 import edu.wpi.first.units.measure.Time;
 import edu.wpi.first.units.measure.Voltage;
 import edu.wpi.first.wpilibj.simulation.FlywheelSim;
@@ -30,7 +31,7 @@ public class MotorOutputFlywheelSim implements MotorOutput{
   private final DCMotor motor;
 
   /** Position of flywhell (found by integrating sim velocity) */
-  private Angle position;
+  private MutAngle position;
 
   /** Voltage to overcome static friction */
   private final double kS;
@@ -57,6 +58,7 @@ public class MotorOutputFlywheelSim implements MotorOutput{
     LinearSystem<N1, N1, N1> plant = LinearSystemId.createFlywheelSystem(motor, moi.in(KilogramSquareMeters), config.rotorToSensorRatio()*config.sensorToMechRatio());
     sim = new FlywheelSim(plant, motor);
     this.kS = kS;
+    this.position = Rotations.mutable(0.0);
   }
 
   @Override
@@ -77,15 +79,15 @@ public class MotorOutputFlywheelSim implements MotorOutput{
   @Override
   public void updateValues(MotorValues values, Time dt) {
     sim.update(dt.in(Seconds));
-    position = position.plus(sim.getAngularVelocity().times(dt));
+    position.mut_plus(sim.getAngularVelocity().times(dt));
 
-    values.position = position;
-    values.velocity = sim.getAngularVelocity();
-    values.acceleration = sim.getAngularAcceleration();
-    values.motorVoltage = Volts.of(sim.getInputVoltage());
-    values.supplyVoltage = Volts.of(sim.getInputVoltage());
-    values.statorCurrent = Amps.of(0.0); //TODO not sure how to actually calculate this
-    values.supplyCurrent = Amps.of(sim.getCurrentDrawAmps()); //TODO not sure if this represents supply or stator current
+    values.position.mut_replace(position);
+    values.velocity.mut_replace(sim.getAngularVelocity());
+    values.acceleration.mut_replace(sim.getAngularAcceleration());
+    values.motorVoltage.mut_replace(sim.getInputVoltage(), Volts);
+    values.supplyVoltage.mut_replace(sim.getInputVoltage(), Volts);
+    values.statorCurrent.mut_replace(0, Amps); //TODO not sure how to actually calculate this
+    values.supplyCurrent.mut_replace(sim.getCurrentDrawAmps(), Amps); //TODO not sure if this represents supply or stator current
   }
 
   @Override

--- a/src/main/java/frc/lib/motors/MotorOutputTalonFX.java
+++ b/src/main/java/frc/lib/motors/MotorOutputTalonFX.java
@@ -1,5 +1,11 @@
 package frc.lib.motors;
 
+import static edu.wpi.first.units.Units.Amps;
+import static edu.wpi.first.units.Units.Rotations;
+import static edu.wpi.first.units.Units.RotationsPerSecond;
+import static edu.wpi.first.units.Units.RotationsPerSecondPerSecond;
+import static edu.wpi.first.units.Units.Volts;
+
 import com.ctre.phoenix6.BaseStatusSignal;
 import com.ctre.phoenix6.StatusSignal;
 import com.ctre.phoenix6.configs.CurrentLimitsConfigs;
@@ -80,13 +86,13 @@ public class MotorOutputTalonFX implements MotorOutput {
   public void updateValues(MotorValues values, Time dt) {
     BaseStatusSignal.refreshAll(position, velocity, acceleration, motorVoltage, supplyVoltage, statorCurrent, supplyCurrent);
 
-    values.position.mut_replace(position.getValue());
-    values.velocity.mut_replace(velocity.getValue());
-    values.acceleration.mut_replace(acceleration.getValue());
-    values.motorVoltage.mut_replace(motorVoltage.getValue());
-    values.supplyVoltage.mut_replace(supplyVoltage.getValue());
-    values.statorCurrent.mut_replace(statorCurrent.getValue());
-    values.supplyCurrent.mut_replace(supplyCurrent.getValue());
+    values.position.mut_replace(position.getValueAsDouble(), Rotations);
+    values.velocity.mut_replace(velocity.getValueAsDouble(), RotationsPerSecond);
+    values.acceleration.mut_replace(acceleration.getValueAsDouble(), RotationsPerSecondPerSecond);
+    values.motorVoltage.mut_replace(motorVoltage.getValueAsDouble(), Volts);
+    values.supplyVoltage.mut_replace(supplyVoltage.getValueAsDouble(), Volts);
+    values.statorCurrent.mut_replace(statorCurrent.getValueAsDouble(), Amps);
+    values.supplyCurrent.mut_replace(supplyCurrent.getValueAsDouble(), Amps);
   }
 
   @Override

--- a/src/main/java/frc/lib/motors/MotorOutputTalonFX.java
+++ b/src/main/java/frc/lib/motors/MotorOutputTalonFX.java
@@ -80,13 +80,13 @@ public class MotorOutputTalonFX implements MotorOutput {
   public void updateValues(MotorValues values, Time dt) {
     BaseStatusSignal.refreshAll(position, velocity, acceleration, motorVoltage, supplyVoltage, statorCurrent, supplyCurrent);
 
-    values.position = position.getValue();
-    values.velocity = velocity.getValue();
-    values.acceleration = acceleration.getValue();
-    values.motorVoltage = motorVoltage.getValue();
-    values.supplyVoltage = supplyVoltage.getValue();
-    values.statorCurrent = statorCurrent.getValue();
-    values.supplyCurrent = supplyCurrent.getValue();
+    values.position.mut_replace(position.getValue());
+    values.velocity.mut_replace(velocity.getValue());
+    values.acceleration.mut_replace(acceleration.getValue());
+    values.motorVoltage.mut_replace(motorVoltage.getValue());
+    values.supplyVoltage.mut_replace(supplyVoltage.getValue());
+    values.statorCurrent.mut_replace(statorCurrent.getValue());
+    values.supplyCurrent.mut_replace(supplyCurrent.getValue());
   }
 
   @Override

--- a/src/main/java/frc/lib/motors/MotorOutputTalonFX2.java
+++ b/src/main/java/frc/lib/motors/MotorOutputTalonFX2.java
@@ -90,13 +90,13 @@ public class MotorOutputTalonFX2 implements MotorOutput {
   public void updateValues(MotorValues values, Time dt) {
     BaseStatusSignal.refreshAll(position, velocity, acceleration, motorVoltage, supplyVoltage, statorCurrent, supplyCurrent);
 
-    values.position = position.getValue();
-    values.velocity = velocity.getValue();
-    values.acceleration = acceleration.getValue();
-    values.motorVoltage = motorVoltage.getValue();
-    values.supplyVoltage = supplyVoltage.getValue();
-    values.statorCurrent = statorCurrent.getValue();
-    values.supplyCurrent = supplyCurrent.getValue();
+    values.position.mut_replace(position.getValue());
+    values.velocity.mut_replace(velocity.getValue());
+    values.acceleration.mut_replace(acceleration.getValue());
+    values.motorVoltage.mut_replace(motorVoltage.getValue());
+    values.supplyVoltage.mut_replace(supplyVoltage.getValue());
+    values.statorCurrent.mut_replace(statorCurrent.getValue());
+    values.supplyCurrent.mut_replace(supplyCurrent.getValue());
   }
 
   @Override

--- a/src/main/java/frc/lib/motors/MotorOutputTalonFX2.java
+++ b/src/main/java/frc/lib/motors/MotorOutputTalonFX2.java
@@ -1,5 +1,11 @@
 package frc.lib.motors;
 
+import static edu.wpi.first.units.Units.Amps;
+import static edu.wpi.first.units.Units.Rotations;
+import static edu.wpi.first.units.Units.RotationsPerSecond;
+import static edu.wpi.first.units.Units.RotationsPerSecondPerSecond;
+import static edu.wpi.first.units.Units.Volts;
+
 import com.ctre.phoenix6.BaseStatusSignal;
 import com.ctre.phoenix6.StatusSignal;
 import com.ctre.phoenix6.configs.CurrentLimitsConfigs;
@@ -90,13 +96,13 @@ public class MotorOutputTalonFX2 implements MotorOutput {
   public void updateValues(MotorValues values, Time dt) {
     BaseStatusSignal.refreshAll(position, velocity, acceleration, motorVoltage, supplyVoltage, statorCurrent, supplyCurrent);
 
-    values.position.mut_replace(position.getValue());
-    values.velocity.mut_replace(velocity.getValue());
-    values.acceleration.mut_replace(acceleration.getValue());
-    values.motorVoltage.mut_replace(motorVoltage.getValue());
-    values.supplyVoltage.mut_replace(supplyVoltage.getValue());
-    values.statorCurrent.mut_replace(statorCurrent.getValue());
-    values.supplyCurrent.mut_replace(supplyCurrent.getValue());
+    values.position.mut_replace(position.getValueAsDouble(), Rotations);
+    values.velocity.mut_replace(velocity.getValueAsDouble(), RotationsPerSecond);
+    values.acceleration.mut_replace(acceleration.getValueAsDouble(), RotationsPerSecondPerSecond);
+    values.motorVoltage.mut_replace(motorVoltage.getValueAsDouble(), Volts);
+    values.supplyVoltage.mut_replace(supplyVoltage.getValueAsDouble(), Volts);
+    values.statorCurrent.mut_replace(statorCurrent.getValueAsDouble(), Amps);
+    values.supplyCurrent.mut_replace(supplyCurrent.getValueAsDouble(), Amps);
   }
 
   @Override

--- a/src/main/java/frc/lib/motors/MotorValues.java
+++ b/src/main/java/frc/lib/motors/MotorValues.java
@@ -6,34 +6,34 @@ import static edu.wpi.first.units.Units.RotationsPerSecond;
 import static edu.wpi.first.units.Units.RotationsPerSecondPerSecond;
 import static edu.wpi.first.units.Units.Volts;
 
-import edu.wpi.first.units.measure.Angle;
-import edu.wpi.first.units.measure.AngularAcceleration;
-import edu.wpi.first.units.measure.AngularVelocity;
-import edu.wpi.first.units.measure.Current;
-import edu.wpi.first.units.measure.Voltage;
+import edu.wpi.first.units.measure.MutAngle;
+import edu.wpi.first.units.measure.MutAngularAcceleration;
+import edu.wpi.first.units.measure.MutAngularVelocity;
+import edu.wpi.first.units.measure.MutCurrent;
+import edu.wpi.first.units.measure.MutVoltage;
 
 /** Class that contains motor output values */
 public class MotorValues {
   
   /** Current position of motor */
-  public Angle position = Rotations.of(0.0);
+  public MutAngle position = Rotations.mutable(0.0);
 
   /** Current velocity of motor */
-  public AngularVelocity velocity = RotationsPerSecond.of(0.0);
+  public MutAngularVelocity velocity = RotationsPerSecond.mutable(0.0);
 
   /** Current acceleration of motor */
-  public AngularAcceleration acceleration = RotationsPerSecondPerSecond.of(0.0);
+  public MutAngularAcceleration acceleration = RotationsPerSecondPerSecond.mutable(0.0);
 
   /** Current armature voltage  */
-  public Voltage motorVoltage = Volts.of(0.0);
+  public MutVoltage motorVoltage = Volts.mutable(0.0);
 
   /** Current supply voltage */
-  public Voltage supplyVoltage = Volts.of(0.0);
+  public MutVoltage supplyVoltage = Volts.mutable(0.0);
 
   /** Current stator current */
-  public Current statorCurrent = Amps.of(0.0);
+  public MutCurrent statorCurrent = Amps.mutable(0.0);
 
   /** Current supply current */
-  public Current supplyCurrent = Amps.of(0.0);
+  public MutCurrent supplyCurrent = Amps.mutable(0.0);
   
 }


### PR DESCRIPTION
Replaced measures in values classes with MutableMeasures

Do we know if StatusSignal.getValueAsDouble() has less overhaed than StatusSignal.getValue()? Because if it does I could change `values.<value>.mut_replace(StatusSignal.getValue())` to `values.<value>.mut_replace(StatusSIgnal.getValueAsDouble(), Unit)`, though that would be less unit safe if we don't know the units a device will return values in (we would in practice but yknow)