### PR TITLE
Fix elevator sim

### DIFF
--- a/src/main/java/frc/lib/motors/LossyMotorOutputSim.java
+++ b/src/main/java/frc/lib/motors/LossyMotorOutputSim.java
@@ -2,6 +2,7 @@ package frc.lib.motors;
 
 import static edu.wpi.first.units.Units.*;
 
+import edu.wpi.first.math.MathUtil;
 import edu.wpi.first.units.measure.Angle;
 import edu.wpi.first.units.measure.MutAngle;
 import edu.wpi.first.units.measure.MutVoltage;
@@ -73,7 +74,7 @@ public class LossyMotorOutputSim implements MotorOutput {
         this.motorVoltage.mut_replace(voltage);
         double volts = voltage.in(Volts);
         effectiveMotorVoltage.mut_replace(
-            volts - calculateVoltageLoss(volts),
+            calculateEffectiveVoltage(volts),
             Volts
         );
         // Override the requested voltage with the effective voltage
@@ -81,18 +82,22 @@ public class LossyMotorOutputSim implements MotorOutput {
     }
 
     /**
-     * Calculates the voltage losses due to static friction and gravity.
+     * Calculates effective voltage applied to motor that produces movement (voltage not used to overcome gravity or static friction)
      *
      * @param voltage The voltage being applied to the system, prior to any losses.
-     * @return The voltage loss due to static friction and gravity.
+     * @return Effective voltage applied to the motor that produces movement
      */
-    private double calculateVoltageLoss(double voltage) {
+    private double calculateEffectiveVoltage(double voltage) {
         double kS = this.kS.in(Volts);
         double kG = this.kG.apply(position).in(Volts);
-        if (Math.abs(voltage) < kS) {
-            return kG;
+        double voltageOut = voltage - kG;
+        if (Math.abs(voltageOut) < kS) {
+            voltageOut = 0;
+        } else {
+            voltageOut -= Math.copySign(kS, voltageOut);
         }
-        return Math.copySign(kS, voltage) + kG;
+
+        return voltageOut;
     }
 
     @Override

--- a/src/main/java/frc/lib/motors/LossyMotorOutputSim.java
+++ b/src/main/java/frc/lib/motors/LossyMotorOutputSim.java
@@ -2,7 +2,6 @@ package frc.lib.motors;
 
 import static edu.wpi.first.units.Units.*;
 
-import edu.wpi.first.math.MathUtil;
 import edu.wpi.first.units.measure.Angle;
 import edu.wpi.first.units.measure.MutAngle;
 import edu.wpi.first.units.measure.MutVoltage;

--- a/src/main/java/frc/robot/elevator/Elevator.java
+++ b/src/main/java/frc/robot/elevator/Elevator.java
@@ -112,13 +112,13 @@ public class Elevator extends MultithreadedSubsystem {
   /** Mechanism config */
   private final MechanismConfig config = MechanismBuilder.defaults()
     .feedforwardControllerConfig(FeedforwardControllerBuilder.defaults()
-      .kV(2.0)
-      .kA(0.2)
+      .kV(0.5843)
+      .kA(0.05843)
       .kG(0.57)
       .kS(0.155)
       .build())
     .feedbackControllerConfig(FeedbackControllerBuilder.defaults()
-      .kP(32)
+      .kP(10)
       .kI(0.0)
       .kD(0.0)
       .build())
@@ -254,12 +254,12 @@ public class Elevator extends MultithreadedSubsystem {
 
     if (manualVoltageSet == false) {
       // If no manual voltage set, calculate voltage using feedforward and feedback
-      feedforwardVolts = feedforwardController.calculate(profiledSetpoint.velocity);
+      feedforwardVolts = feedforwardController.calculate(profiledSetpoint.velocity / metersPerRotation);
       feedbackVolts = 0.0;
       
       if (MathUtil.isNear(0.0, motorValues.velocity.in(RotationsPerSecond) * metersPerRotation, PIDThreshold.in(MetersPerSecond)) && currentState == targetState) {
         // If target velocity is close enough to zero, meaning you are reacing the end of a trajectory, fade in some feedback voltage
-        feedbackVolts = feedbackController.calculate(position.in(Meters), profiledSetpoint.position);
+        feedbackVolts = feedbackController.calculate(position.in(Meters) / metersPerRotation, profiledSetpoint.position / metersPerRotation);
 
         // Calculation to fade in PID voltage smoothly based on velocity's closeness to 0
         double t = Math.abs(motorValues.velocity.in(RotationsPerSecond) * metersPerRotation)/PIDThreshold.in(MetersPerSecond); // This gives the value of current velocity as a percentage of PIDThreshold

--- a/src/main/java/frc/robot/elevator/Elevator.java
+++ b/src/main/java/frc/robot/elevator/Elevator.java
@@ -53,7 +53,7 @@ public class Elevator extends MultithreadedSubsystem {
   private MotorValues motorValues = new MotorValues();
 
   /** Ratio of meters travelled by elevator per rotations made by motor output */
-  private final double rotationsToMeters;
+  private final double metersPerRotation;
 
   // State related
 
@@ -153,7 +153,7 @@ public class Elevator extends MultithreadedSubsystem {
   private Elevator() {
     motorOutput = ElevatorFactory.createMotorOutput(config);
 
-    rotationsToMeters = 0.031 * Math.PI * 3;
+    metersPerRotation = 0.031 * Math.PI * 3;
 
     currentState = ElevatorState.STOW;
     targetState = ElevatorState.STOW;
@@ -196,9 +196,9 @@ public class Elevator extends MultithreadedSubsystem {
     // Current state column
     ShuffleboardLayout stateColumn = tab.getLayout("Current state", BuiltInLayouts.kList);
 
-    stateColumn.addDouble("Elevator position (m)", () -> motorValues.position.in(Rotations) * rotationsToMeters);
-    stateColumn.addDouble("Elevator velocity (mps)", () -> motorValues.velocity.in(RotationsPerSecond) * rotationsToMeters);
-    stateColumn.addDouble("Elevator acceleration (mpsps)", () -> motorValues.acceleration.in(RotationsPerSecondPerSecond) * rotationsToMeters);
+    stateColumn.addDouble("Elevator position (m)", () -> motorValues.position.in(Rotations) * metersPerRotation);
+    stateColumn.addDouble("Elevator velocity (mps)", () -> motorValues.velocity.in(RotationsPerSecond) * metersPerRotation);
+    stateColumn.addDouble("Elevator acceleration (mpsps)", () -> motorValues.acceleration.in(RotationsPerSecondPerSecond) * metersPerRotation);
     stateColumn.addDouble("Motor position (rot)", () -> motorValues.position.in(Rotations));
     stateColumn.addDouble("Motor velocity (rotps)", () -> motorValues.velocity.in(RotationsPerSecond));
     stateColumn.addDouble("Motor acceleration (rotpsps)", () -> motorValues.acceleration.in(RotationsPerSecondPerSecond));
@@ -219,7 +219,7 @@ public class Elevator extends MultithreadedSubsystem {
   public void fastPeriodic() {
     motorOutput.updateValues(motorValues, Seconds.of(RobotConstants.FAST_PERIODIC_DURATION));
 
-    Distance position = Meters.of(motorValues.position.in(Rotations) * rotationsToMeters);
+    Distance position = Meters.of(motorValues.position.in(Rotations) * metersPerRotation);
 
     updateMechanismVisualization(position);
 
@@ -257,12 +257,12 @@ public class Elevator extends MultithreadedSubsystem {
       feedforwardVolts = feedforwardController.calculate(profiledSetpoint.velocity);
       feedbackVolts = 0.0;
       
-      if (MathUtil.isNear(0.0, motorValues.velocity.in(RotationsPerSecond) * rotationsToMeters, PIDThreshold.in(MetersPerSecond)) && currentState == targetState) {
+      if (MathUtil.isNear(0.0, motorValues.velocity.in(RotationsPerSecond) * metersPerRotation, PIDThreshold.in(MetersPerSecond)) && currentState == targetState) {
         // If target velocity is close enough to zero, meaning you are reacing the end of a trajectory, fade in some feedback voltage
         feedbackVolts = feedbackController.calculate(position.in(Meters), profiledSetpoint.position);
 
         // Calculation to fade in PID voltage smoothly based on velocity's closeness to 0
-        double t = Math.abs(motorValues.velocity.in(RotationsPerSecond) * rotationsToMeters)/PIDThreshold.in(MetersPerSecond); // This gives the value of current velocity as a percentage of PIDThreshold
+        double t = Math.abs(motorValues.velocity.in(RotationsPerSecond) * metersPerRotation)/PIDThreshold.in(MetersPerSecond); // This gives the value of current velocity as a percentage of PIDThreshold
         t = t * -1 + 1; // Inverting and adding 1 means now 0.0 refers to a velocity of PIDThreshold, and 1.0 refers to a velocity of 0; this could already be multiplied by PID voltage for a linear fade in
         t = Math.pow(t, PIDSmoothing); // This smooths the linear interpolation based on PIDSmoothing (to understand this go into desmos, graph x^a, and vary a. a is PIDSmoothing, and x is the value of t before this calculation)
 
@@ -282,7 +282,7 @@ public class Elevator extends MultithreadedSubsystem {
    * @param newPos new position of the elevator
    */
   private void setPosition(Distance newPos) {
-    motorOutput.setPosition(Rotations.of(newPos.in(Meters) / rotationsToMeters));
+    motorOutput.setPosition(Rotations.of(newPos.in(Meters) / metersPerRotation));
   }
 
   /**

--- a/src/main/java/frc/robot/elevator/ElevatorFactory.java
+++ b/src/main/java/frc/robot/elevator/ElevatorFactory.java
@@ -2,6 +2,7 @@ package frc.robot.elevator;
 
 import static edu.wpi.first.units.Units.RadiansPerSecond;
 import static edu.wpi.first.units.Units.RadiansPerSecondPerSecond;
+import static edu.wpi.first.units.Units.Rotations;
 import static edu.wpi.first.units.Units.Volts;
 
 import edu.wpi.first.math.system.plant.DCMotor;
@@ -49,7 +50,9 @@ public class ElevatorFactory {
         return new LossyMotorOutputSim(
             motor,
             Volts.of(config.feedforwardControllerConfig().kS()),
-            Volts.of(config.feedforwardControllerConfig().kG())
+            (motorPosition) -> {
+                return (motorPosition.in(Rotations) > 0) ? Volts.of(config.feedforwardControllerConfig().kG()) : Volts.of(0.0);
+            }
         );
     }
 }

--- a/src/main/java/frc/robot/elevator/ElevatorFactory.java
+++ b/src/main/java/frc/robot/elevator/ElevatorFactory.java
@@ -1,8 +1,8 @@
 package frc.robot.elevator;
 
-import static edu.wpi.first.units.Units.RadiansPerSecond;
-import static edu.wpi.first.units.Units.RadiansPerSecondPerSecond;
 import static edu.wpi.first.units.Units.Rotations;
+import static edu.wpi.first.units.Units.RotationsPerSecond;
+import static edu.wpi.first.units.Units.RotationsPerSecondPerSecond;
 import static edu.wpi.first.units.Units.Volts;
 
 import edu.wpi.first.math.system.plant.DCMotor;
@@ -38,10 +38,10 @@ public class ElevatorFactory {
         }
 
         var motor = new MotorOutputSim(
-            Volts.per(RadiansPerSecond).ofNative(
+            Volts.per(RotationsPerSecond).ofNative(
                 config.feedforwardControllerConfig().kV()
             ),
-            Volts.per(RadiansPerSecondPerSecond).ofNative(
+            Volts.per(RotationsPerSecondPerSecond).ofNative(
                 config.feedforwardControllerConfig().kA()
             ),
             DCMotor.getKrakenX60(2)


### PR DESCRIPTION
There were a lot of odd issues with the elevator sim, this pr fixes it up and gets things in a working (though far from perfect) state

Problems fixed
- The math for effective voltage calculation was incorrect. I don't really know exactly how, I just knew it was wrong because it didn't look right and clearly wouldn't produce the result I wanted out of it. Instead of figuring out what math was going on and finding where it was going wrong, I just rewrote it to all be done with one function calculateEffectiveVoltage() rather than subtracting the result of calculateVoltageLoss() from input voltage to fix the problem and simplify things a bit.
- The calculations done to apply an effective voltage that simulates kG and kS would always apply negative kG to the elevator no matter what, and when the subsystem code manually set voltage output to 0.25 to stow and fall back to a position of 0 while still keeping some tension on the chains, the simulated elevator would just keep on falling past 0 forever. To fix this, I changed the constant kG input to the LossyMotorOutputSim constructor to be a Function<Angle, Voltage>,  where if motor position was greater than 0, it would output kG, and otherwise, 0. This causes some weird oscillation and bounciness near 0 when the elevator is stowed, but as a temporary fix, it works well enough
- After the kG fix, position and velocity generally followed setpoint position and velocity pretty well, but they were scaled down by around a factor of 2 for some reason. This fix took a bit longer, but the issue was caused by the incorrect units of kV and kA in the MotorOutputSim constructor, using volts per radians per second and radians per second per second, while the config's kV and kA values were in volts per meters per second and meters per second per second. To fix this issue, I changed the units of all control gains that were defined with respect to meters to be defined with respect to rotations, did the appropriate conversions in feedbackController and feedforwardController .calculate() methods, and changed the units in the MotorOutputSim constructor to be volts per rotations per second and volts per rotations per second per second.
- I also changed the name of rotationsToMeters to metersPerRotation so the units of the conversion factor were more obvious without needing to look at the javadoc for the variable