### PR TITLE
Add IdealSwerveSim

### DIFF
--- a/src/main/java/frc/lib/swerves/IdealSwerveSim.java
+++ b/src/main/java/frc/lib/swerves/IdealSwerveSim.java
@@ -1,0 +1,78 @@
+package frc.lib.swerves;
+
+import com.ctre.phoenix6.swerve.SwerveDrivetrain;
+import com.ctre.phoenix6.swerve.SwerveRequest;
+import edu.wpi.first.math.Matrix;
+import edu.wpi.first.math.geometry.Pose2d;
+import edu.wpi.first.math.geometry.Rotation2d;
+import edu.wpi.first.math.numbers.N1;
+import edu.wpi.first.math.numbers.N3;
+import edu.wpi.first.units.measure.Time;
+
+import static edu.wpi.first.units.Units.Seconds;
+
+public class IdealSwerveSim implements SwerveOutput {
+
+    private final Time DT = Seconds.of(0.02);
+
+    private final SwerveDrivetrain.SwerveDriveState state;
+
+    public IdealSwerveSim() {
+        this.state = new SwerveDrivetrain.SwerveDriveState();
+    }
+
+    @Override
+    public void setControl(SwerveRequest request) {
+        if (request instanceof SwerveRequest.FieldCentric) {
+            handleFieldCentric((SwerveRequest.FieldCentric) request);
+        }
+
+        if (request instanceof SwerveRequest.FieldCentricFacingAngle) {
+            handleFieldCentricFacingAngle((SwerveRequest.FieldCentricFacingAngle) request);
+        }
+    }
+
+    private void handleFieldCentric(SwerveRequest.FieldCentric request) {
+        double vx = request.VelocityX;
+        double vy = request.VelocityY;
+        double omega = request.RotationalRate;
+        double dt = DT.in(Seconds);
+
+        double x = state.Pose.getX() + vx * dt;
+        double y = state.Pose.getY() + vy * dt;
+        double angle = state.Pose.getRotation().getRadians() + omega * dt;
+
+        state.Pose = new Pose2d(x, y, Rotation2d.fromRadians(angle));
+    }
+
+    private void handleFieldCentricFacingAngle(SwerveRequest.FieldCentricFacingAngle request) {
+        double vx = request.VelocityX;
+        double vy = request.VelocityY;
+        double dt = DT.in(Seconds);
+
+        double x = state.Pose.getX() + vx * dt;
+        double y = state.Pose.getY() + vy * dt;
+
+        state.Pose = new Pose2d(x, y, request.TargetDirection);
+    }
+
+    @Override
+    public SwerveDrivetrain.SwerveDriveState getState() {
+        return state;
+    }
+
+    @Override
+    public void addVisionMeasurement(Pose2d visionPose, double timestampSeconds) {
+        state.Pose = visionPose;
+    }
+
+    @Override
+    public void addVisionMeasurement(Pose2d visionPose, double timestampSeconds, Matrix<N3, N1> visionStdDevs) {
+        addVisionMeasurement(visionPose, timestampSeconds);
+    }
+
+    @Override
+    public void setOperatorPerspectiveForward(Rotation2d fieldDirection) {
+        // TODO No-op for simulation, since we are always driving relative to the field
+    }
+}

--- a/src/main/java/frc/lib/swerves/IdealSwerveSim.java
+++ b/src/main/java/frc/lib/swerves/IdealSwerveSim.java
@@ -1,5 +1,7 @@
 package frc.lib.swerves;
 
+import static edu.wpi.first.units.Units.Seconds;
+
 import com.ctre.phoenix6.swerve.SwerveDrivetrain;
 import com.ctre.phoenix6.swerve.SwerveRequest;
 import edu.wpi.first.math.Matrix;
@@ -9,70 +11,69 @@ import edu.wpi.first.math.numbers.N1;
 import edu.wpi.first.math.numbers.N3;
 import edu.wpi.first.units.measure.Time;
 
-import static edu.wpi.first.units.Units.Seconds;
-
 public class IdealSwerveSim implements SwerveOutput {
 
-    private final Time DT = Seconds.of(0.02);
+  private final Time DT = Seconds.of(0.02);
 
-    private final SwerveDrivetrain.SwerveDriveState state;
+  private final SwerveDrivetrain.SwerveDriveState state;
 
-    public IdealSwerveSim() {
-        this.state = new SwerveDrivetrain.SwerveDriveState();
+  public IdealSwerveSim() {
+    this.state = new SwerveDrivetrain.SwerveDriveState();
+  }
+
+  @Override
+  public void setControl(SwerveRequest request) {
+    if (request instanceof SwerveRequest.FieldCentric) {
+      handleFieldCentric((SwerveRequest.FieldCentric) request);
     }
 
-    @Override
-    public void setControl(SwerveRequest request) {
-        if (request instanceof SwerveRequest.FieldCentric) {
-            handleFieldCentric((SwerveRequest.FieldCentric) request);
-        }
-
-        if (request instanceof SwerveRequest.FieldCentricFacingAngle) {
-            handleFieldCentricFacingAngle((SwerveRequest.FieldCentricFacingAngle) request);
-        }
+    if (request instanceof SwerveRequest.FieldCentricFacingAngle) {
+      handleFieldCentricFacingAngle((SwerveRequest.FieldCentricFacingAngle) request);
     }
+  }
 
-    private void handleFieldCentric(SwerveRequest.FieldCentric request) {
-        double vx = request.VelocityX;
-        double vy = request.VelocityY;
-        double omega = request.RotationalRate;
-        double dt = DT.in(Seconds);
+  private void handleFieldCentric(SwerveRequest.FieldCentric request) {
+    double vx = request.VelocityX;
+    double vy = request.VelocityY;
+    double omega = request.RotationalRate;
+    double dt = DT.in(Seconds);
 
-        double x = state.Pose.getX() + vx * dt;
-        double y = state.Pose.getY() + vy * dt;
-        double angle = state.Pose.getRotation().getRadians() + omega * dt;
+    double x = state.Pose.getX() + vx * dt;
+    double y = state.Pose.getY() + vy * dt;
+    double angle = state.Pose.getRotation().getRadians() + omega * dt;
 
-        state.Pose = new Pose2d(x, y, Rotation2d.fromRadians(angle));
-    }
+    state.Pose = new Pose2d(x, y, Rotation2d.fromRadians(angle));
+  }
 
-    private void handleFieldCentricFacingAngle(SwerveRequest.FieldCentricFacingAngle request) {
-        double vx = request.VelocityX;
-        double vy = request.VelocityY;
-        double dt = DT.in(Seconds);
+  private void handleFieldCentricFacingAngle(SwerveRequest.FieldCentricFacingAngle request) {
+    double vx = request.VelocityX;
+    double vy = request.VelocityY;
+    double dt = DT.in(Seconds);
 
-        double x = state.Pose.getX() + vx * dt;
-        double y = state.Pose.getY() + vy * dt;
+    double x = state.Pose.getX() + vx * dt;
+    double y = state.Pose.getY() + vy * dt;
 
-        state.Pose = new Pose2d(x, y, request.TargetDirection);
-    }
+    state.Pose = new Pose2d(x, y, request.TargetDirection);
+  }
 
-    @Override
-    public SwerveDrivetrain.SwerveDriveState getState() {
-        return state;
-    }
+  @Override
+  public SwerveDrivetrain.SwerveDriveState getState() {
+    return state;
+  }
 
-    @Override
-    public void addVisionMeasurement(Pose2d visionPose, double timestampSeconds) {
-        state.Pose = visionPose;
-    }
+  @Override
+  public void addVisionMeasurement(Pose2d visionPose, double timestampSeconds) {
+    state.Pose = visionPose;
+  }
 
-    @Override
-    public void addVisionMeasurement(Pose2d visionPose, double timestampSeconds, Matrix<N3, N1> visionStdDevs) {
-        addVisionMeasurement(visionPose, timestampSeconds);
-    }
+  @Override
+  public void addVisionMeasurement(
+      Pose2d visionPose, double timestampSeconds, Matrix<N3, N1> visionStdDevs) {
+    addVisionMeasurement(visionPose, timestampSeconds);
+  }
 
-    @Override
-    public void setOperatorPerspectiveForward(Rotation2d fieldDirection) {
-        // TODO No-op for simulation, since we are always driving relative to the field
-    }
+  @Override
+  public void setOperatorPerspectiveForward(Rotation2d fieldDirection) {
+    // TODO No-op for simulation, since we are always driving relative to the field
+  }
 }

--- a/src/main/java/frc/lib/swerves/SwerveOutput.java
+++ b/src/main/java/frc/lib/swerves/SwerveOutput.java
@@ -10,14 +10,14 @@ import edu.wpi.first.math.numbers.N3;
 
 public interface SwerveOutput {
 
-    void setControl(SwerveRequest request);
+  void setControl(SwerveRequest request);
 
-    SwerveDrivetrain.SwerveDriveState getState();
+  SwerveDrivetrain.SwerveDriveState getState();
 
-    void addVisionMeasurement(Pose2d visionPose, double timestampSeconds);
+  void addVisionMeasurement(Pose2d visionPose, double timestampSeconds);
 
-    void addVisionMeasurement(Pose2d visionPose, double timestampSeconds, Matrix<N3, N1> visionStdDevs);
+  void addVisionMeasurement(
+      Pose2d visionPose, double timestampSeconds, Matrix<N3, N1> visionStdDevs);
 
-    void setOperatorPerspectiveForward(Rotation2d fieldDirection);
-
+  void setOperatorPerspectiveForward(Rotation2d fieldDirection);
 }

--- a/src/main/java/frc/lib/swerves/SwerveOutput.java
+++ b/src/main/java/frc/lib/swerves/SwerveOutput.java
@@ -1,0 +1,23 @@
+package frc.lib.swerves;
+
+import com.ctre.phoenix6.swerve.SwerveDrivetrain;
+import com.ctre.phoenix6.swerve.SwerveRequest;
+import edu.wpi.first.math.Matrix;
+import edu.wpi.first.math.geometry.Pose2d;
+import edu.wpi.first.math.geometry.Rotation2d;
+import edu.wpi.first.math.numbers.N1;
+import edu.wpi.first.math.numbers.N3;
+
+public interface SwerveOutput {
+
+    void setControl(SwerveRequest request);
+
+    SwerveDrivetrain.SwerveDriveState getState();
+
+    void addVisionMeasurement(Pose2d visionPose, double timestampSeconds);
+
+    void addVisionMeasurement(Pose2d visionPose, double timestampSeconds, Matrix<N3, N1> visionStdDevs);
+
+    void setOperatorPerspectiveForward(Rotation2d fieldDirection);
+
+}

--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -4,15 +4,20 @@
 
 package frc.robot;
 
-import static edu.wpi.first.units.Units.Meters;
-
+import edu.wpi.first.math.MathUtil;
+import edu.wpi.first.math.kinematics.ChassisSpeeds;
+import edu.wpi.first.units.measure.AngularVelocity;
+import edu.wpi.first.units.measure.LinearVelocity;
 import edu.wpi.first.wpilibj2.command.Command;
 import edu.wpi.first.wpilibj2.command.Commands;
 import edu.wpi.first.wpilibj2.command.button.CommandXboxController;
 import frc.lib.Telemetry;
+import frc.robot.drive.Drive;
+import frc.robot.drive.DriveFactory;
 import frc.robot.elevator.Elevator;
 import frc.robot.elevator.ElevatorState;
 import frc.robot.pivot.Pivot;
+import static edu.wpi.first.units.Units.*;
 
 /** Robot container */
 public class RobotContainer {
@@ -35,6 +40,8 @@ public class RobotContainer {
   /** Pivot subsystem reference */
   private final Pivot pivot;
 
+  private final Drive drive;
+
   /** Initializes the robot container */
   private RobotContainer() {
     driverController = new CommandXboxController(0);
@@ -44,7 +51,9 @@ public class RobotContainer {
 
     pivot = Pivot.getInstance();
 
-    Telemetry.initializeTabs(elevator, pivot);
+    drive = new Drive(DriveFactory.createSwerve());
+
+    Telemetry.initializeTabs(elevator, pivot, drive);
 
     multithreader = Multithreader.getInstance();
     multithreader.start();
@@ -66,8 +75,23 @@ public class RobotContainer {
     return instance;
   }
 
+  private ChassisSpeeds getFieldSpeeds() {
+      LinearVelocity MAX_VELOCITY = MetersPerSecond.of(2);
+      AngularVelocity MAX_ANGULAR_VELOCITY = RotationsPerSecond.of(0.5);
+      var x = MathUtil.applyDeadband(-driverController.getLeftY(), 0.1);
+      var y = MathUtil.applyDeadband(-driverController.getLeftX(), 0.1);
+      var omega = MathUtil.applyDeadband(-driverController.getRightX(), 0.1);
+      return new ChassisSpeeds(
+          MAX_VELOCITY.times(x),
+          MAX_VELOCITY.times(y),
+          MAX_ANGULAR_VELOCITY.times(omega)
+      );
+  }
+
   /** Configures subsystem default commands for teleop */
-  public void configureDefaultCommands() {}
+  public void configureDefaultCommands() {
+      drive.setDefaultCommand(drive.drive(this::getFieldSpeeds));
+  }
 
   /** Configures controller bindings */
   private void configureBindings() {
@@ -79,10 +103,6 @@ public class RobotContainer {
   }
 
   public Command getAutonomousCommand() {
-    if (RobotConstants.ENABLED_SUBSYSTEMS.contains(RobotConstants.Subsystem.AUTO)) {
-      ;
-    }
-
-    return Commands.print("Auto disabled");
+      return Commands.print("No autonomous command selected...");
   }
 }

--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -4,6 +4,8 @@
 
 package frc.robot;
 
+import static edu.wpi.first.units.Units.*;
+
 import edu.wpi.first.math.MathUtil;
 import edu.wpi.first.math.kinematics.ChassisSpeeds;
 import edu.wpi.first.units.measure.AngularVelocity;
@@ -17,7 +19,6 @@ import frc.robot.drive.DriveFactory;
 import frc.robot.elevator.Elevator;
 import frc.robot.elevator.ElevatorState;
 import frc.robot.pivot.Pivot;
-import static edu.wpi.first.units.Units.*;
 
 /** Robot container */
 public class RobotContainer {
@@ -76,21 +77,18 @@ public class RobotContainer {
   }
 
   private ChassisSpeeds getFieldSpeeds() {
-      LinearVelocity MAX_VELOCITY = MetersPerSecond.of(2);
-      AngularVelocity MAX_ANGULAR_VELOCITY = RotationsPerSecond.of(0.5);
-      var x = MathUtil.applyDeadband(-driverController.getLeftY(), 0.1);
-      var y = MathUtil.applyDeadband(-driverController.getLeftX(), 0.1);
-      var omega = MathUtil.applyDeadband(-driverController.getRightX(), 0.1);
-      return new ChassisSpeeds(
-          MAX_VELOCITY.times(x),
-          MAX_VELOCITY.times(y),
-          MAX_ANGULAR_VELOCITY.times(omega)
-      );
+    LinearVelocity MAX_VELOCITY = MetersPerSecond.of(2);
+    AngularVelocity MAX_ANGULAR_VELOCITY = RotationsPerSecond.of(0.5);
+    var x = MathUtil.applyDeadband(-driverController.getLeftY(), 0.1);
+    var y = MathUtil.applyDeadband(-driverController.getLeftX(), 0.1);
+    var omega = MathUtil.applyDeadband(-driverController.getRightX(), 0.1);
+    return new ChassisSpeeds(
+        MAX_VELOCITY.times(x), MAX_VELOCITY.times(y), MAX_ANGULAR_VELOCITY.times(omega));
   }
 
   /** Configures subsystem default commands for teleop */
   public void configureDefaultCommands() {
-      drive.setDefaultCommand(drive.drive(this::getFieldSpeeds));
+    drive.setDefaultCommand(drive.drive(this::getFieldSpeeds));
   }
 
   /** Configures controller bindings */
@@ -103,6 +101,6 @@ public class RobotContainer {
   }
 
   public Command getAutonomousCommand() {
-      return Commands.print("No autonomous command selected...");
+    return Commands.print("No autonomous command selected...");
   }
 }

--- a/src/main/java/frc/robot/drive/Drive.java
+++ b/src/main/java/frc/robot/drive/Drive.java
@@ -14,144 +14,139 @@ import edu.wpi.first.wpilibj2.command.Command;
 import edu.wpi.first.wpilibj2.command.sysid.SysIdRoutine;
 import frc.lib.Subsystem;
 import frc.lib.swerves.SwerveOutput;
-
 import java.util.function.Supplier;
 
 public class Drive extends Subsystem {
 
-    private final SwerveOutput swerve;
+  private final SwerveOutput swerve;
 
-    private SwerveDrivetrain.SwerveDriveState state;
+  private SwerveDrivetrain.SwerveDriveState state;
 
-    private final Field2d field;
+  private final Field2d field;
 
-    private boolean hasSetPerspective = false;
+  private boolean hasSetPerspective = false;
 
-    public Drive(SwerveOutput swerve) {
-        this.swerve = swerve;
-        this.state = new SwerveDrivetrain.SwerveDriveState();
-        this.field = new Field2d();
-    }
+  public Drive(SwerveOutput swerve) {
+    this.swerve = swerve;
+    this.state = new SwerveDrivetrain.SwerveDriveState();
+    this.field = new Field2d();
+  }
 
-    @Override
-    public void initializeTab() {
-        ShuffleboardTab tab = Shuffleboard.getTab("Swerve");
+  @Override
+  public void initializeTab() {
+    ShuffleboardTab tab = Shuffleboard.getTab("Swerve");
 
-        tab.add(field);
-        tab.addDoubleArray("States", () -> {
-            SwerveModuleState[] states = state.ModuleStates;
-            double[] doubles = new double[8];
+    tab.add(field);
+    tab.addDoubleArray(
+        "States",
+        () -> {
+          SwerveModuleState[] states = state.ModuleStates;
+          double[] doubles = new double[8];
 
-            if (states != null) {
-                for (int i = 0; i < 4; i++) {
-                    SwerveModuleState state = states[i];
-                    doubles[2 * i] = state.angle.getDegrees();
-                    doubles[2 * i + 1] = state.speedMetersPerSecond;
-                }
+          if (states != null) {
+            for (int i = 0; i < 4; i++) {
+              SwerveModuleState state = states[i];
+              doubles[2 * i] = state.angle.getDegrees();
+              doubles[2 * i + 1] = state.speedMetersPerSecond;
             }
+          }
 
-            return doubles;
+          return doubles;
         });
-        tab.addDoubleArray("Targets", () -> {
-            SwerveModuleState[] states = state.ModuleTargets;
-            double[] doubles = new double[8];
+    tab.addDoubleArray(
+        "Targets",
+        () -> {
+          SwerveModuleState[] states = state.ModuleTargets;
+          double[] doubles = new double[8];
 
-            if (states != null) {
-                for (int i = 0; i < 4; i++) {
-                    SwerveModuleState state = states[i];
-                    doubles[2 * i] = state.angle.getDegrees();
-                    doubles[2 * i + 1] = state.speedMetersPerSecond;
-                }
+          if (states != null) {
+            for (int i = 0; i < 4; i++) {
+              SwerveModuleState state = states[i];
+              doubles[2 * i] = state.angle.getDegrees();
+              doubles[2 * i + 1] = state.speedMetersPerSecond;
             }
+          }
 
-            return doubles;
+          return doubles;
         });
-    }
+  }
 
-    @Override
-    public void periodic() {
-        state = swerve.getState();
-        field.setRobotPose(state.Pose);
+  @Override
+  public void periodic() {
+    state = swerve.getState();
+    field.setRobotPose(state.Pose);
 
-        // NOTE This was taken from the generated project, unsure if it is needed
-        // trySettingPerspective();
-    }
+    // NOTE This was taken from the generated project, unsure if it is needed
+    // trySettingPerspective();
+  }
 
-    private void trySettingPerspective() {
-        if (!hasSetPerspective || DriverStation.isDisabled()) {
-            DriverStation.getAlliance().ifPresent(allianceColor -> {
+  private void trySettingPerspective() {
+    if (!hasSetPerspective || DriverStation.isDisabled()) {
+      DriverStation.getAlliance()
+          .ifPresent(
+              allianceColor -> {
                 swerve.setOperatorPerspectiveForward(
-                        allianceColor == DriverStation.Alliance.Red
-                                ? Rotation2d.k180deg
-                                : Rotation2d.kZero
-                );
+                    allianceColor == DriverStation.Alliance.Red
+                        ? Rotation2d.k180deg
+                        : Rotation2d.kZero);
                 hasSetPerspective = true;
-            });
-        }
+              });
     }
+  }
 
-    public Pose2d getPose() {
-        return state.Pose;
-    }
+  public Pose2d getPose() {
+    return state.Pose;
+  }
 
-    public SysIdRoutine createDriveRoutine() {
-        return DriveFactory.createDriveRoutine(swerve, this);
-    }
+  public SysIdRoutine createDriveRoutine() {
+    return DriveFactory.createDriveRoutine(swerve, this);
+  }
 
-    public SysIdRoutine createSteerRoutine() {
-        return DriveFactory.createSteerRoutine(swerve, this);
-    }
+  public SysIdRoutine createSteerRoutine() {
+    return DriveFactory.createSteerRoutine(swerve, this);
+  }
 
-    public SysIdRoutine createRotationRoutine() {
-        return DriveFactory.createRotationRoutine(swerve, this);
-    }
+  public SysIdRoutine createRotationRoutine() {
+    return DriveFactory.createRotationRoutine(swerve, this);
+  }
 
-    public Command sysIdQuasistatic(
-        SysIdRoutine routine,
-        SysIdRoutine.Direction direction
-    ) {
-        return routine.quasistatic(direction);
-    }
+  public Command sysIdQuasistatic(SysIdRoutine routine, SysIdRoutine.Direction direction) {
+    return routine.quasistatic(direction);
+  }
 
-    public Command sysIdDynamic(
-        SysIdRoutine routine,
-        SysIdRoutine.Direction direction
-    ) {
-        return routine.dynamic(direction);
-    }
+  public Command sysIdDynamic(SysIdRoutine routine, SysIdRoutine.Direction direction) {
+    return routine.dynamic(direction);
+  }
 
-    public Command drive(Supplier<ChassisSpeeds> fieldSpeedsSupplier) {
-        // TODO Make factory for requests
-        SwerveRequest.FieldCentric request = new SwerveRequest.FieldCentric();
+  public Command drive(Supplier<ChassisSpeeds> fieldSpeedsSupplier) {
+    // TODO Make factory for requests
+    SwerveRequest.FieldCentric request = new SwerveRequest.FieldCentric();
 
-        return run(() -> {
-            ChassisSpeeds fieldSpeeds = fieldSpeedsSupplier.get();
-            swerve.setControl(
-                request
-                    .withVelocityX(fieldSpeeds.vxMetersPerSecond)
-                    .withVelocityY(fieldSpeeds.vyMetersPerSecond)
-                    .withRotationalRate(fieldSpeeds.omegaRadiansPerSecond)
-            );
+    return run(
+        () -> {
+          ChassisSpeeds fieldSpeeds = fieldSpeedsSupplier.get();
+          swerve.setControl(
+              request
+                  .withVelocityX(fieldSpeeds.vxMetersPerSecond)
+                  .withVelocityY(fieldSpeeds.vyMetersPerSecond)
+                  .withRotationalRate(fieldSpeeds.omegaRadiansPerSecond));
         });
-    }
+  }
 
-    public Command driveFacing(
-        Supplier<ChassisSpeeds> fieldSpeedsSupplier,
-        Supplier<Rotation2d> directionSupplier
-    ) {
-        // TODO Make factory for requests
-        SwerveRequest.FieldCentricFacingAngle request =
-            new SwerveRequest.FieldCentricFacingAngle();
+  public Command driveFacing(
+      Supplier<ChassisSpeeds> fieldSpeedsSupplier, Supplier<Rotation2d> directionSupplier) {
+    // TODO Make factory for requests
+    SwerveRequest.FieldCentricFacingAngle request = new SwerveRequest.FieldCentricFacingAngle();
 
-        return run(() -> {
-            ChassisSpeeds fieldSpeeds = fieldSpeedsSupplier.get();
-            Rotation2d direction = directionSupplier.get();
-            swerve.setControl(
-                request
-                    .withVelocityX(fieldSpeeds.vxMetersPerSecond)
-                    .withVelocityY(fieldSpeeds.vyMetersPerSecond)
-                    .withTargetDirection(direction)
-            );
+    return run(
+        () -> {
+          ChassisSpeeds fieldSpeeds = fieldSpeedsSupplier.get();
+          Rotation2d direction = directionSupplier.get();
+          swerve.setControl(
+              request
+                  .withVelocityX(fieldSpeeds.vxMetersPerSecond)
+                  .withVelocityY(fieldSpeeds.vyMetersPerSecond)
+                  .withTargetDirection(direction));
         });
-    }
+  }
 }

--- a/src/main/java/frc/robot/drive/Drive.java
+++ b/src/main/java/frc/robot/drive/Drive.java
@@ -1,0 +1,157 @@
+package frc.robot.drive;
+
+import com.ctre.phoenix6.swerve.SwerveDrivetrain;
+import com.ctre.phoenix6.swerve.SwerveRequest;
+import edu.wpi.first.math.geometry.Pose2d;
+import edu.wpi.first.math.geometry.Rotation2d;
+import edu.wpi.first.math.kinematics.ChassisSpeeds;
+import edu.wpi.first.math.kinematics.SwerveModuleState;
+import edu.wpi.first.wpilibj.DriverStation;
+import edu.wpi.first.wpilibj.shuffleboard.Shuffleboard;
+import edu.wpi.first.wpilibj.shuffleboard.ShuffleboardTab;
+import edu.wpi.first.wpilibj.smartdashboard.Field2d;
+import edu.wpi.first.wpilibj2.command.Command;
+import edu.wpi.first.wpilibj2.command.sysid.SysIdRoutine;
+import frc.lib.Subsystem;
+import frc.lib.swerves.SwerveOutput;
+
+import java.util.function.Supplier;
+
+public class Drive extends Subsystem {
+
+    private final SwerveOutput swerve;
+
+    private SwerveDrivetrain.SwerveDriveState state;
+
+    private final Field2d field;
+
+    private boolean hasSetPerspective = false;
+
+    public Drive(SwerveOutput swerve) {
+        this.swerve = swerve;
+        this.state = new SwerveDrivetrain.SwerveDriveState();
+        this.field = new Field2d();
+    }
+
+    @Override
+    public void initializeTab() {
+        ShuffleboardTab tab = Shuffleboard.getTab("Swerve");
+
+        tab.add(field);
+        tab.addDoubleArray("States", () -> {
+            SwerveModuleState[] states = state.ModuleStates;
+            double[] doubles = new double[8];
+
+            if (states != null) {
+                for (int i = 0; i < 4; i++) {
+                    SwerveModuleState state = states[i];
+                    doubles[2 * i] = state.angle.getDegrees();
+                    doubles[2 * i + 1] = state.speedMetersPerSecond;
+                }
+            }
+
+            return doubles;
+        });
+        tab.addDoubleArray("Targets", () -> {
+            SwerveModuleState[] states = state.ModuleTargets;
+            double[] doubles = new double[8];
+
+            if (states != null) {
+                for (int i = 0; i < 4; i++) {
+                    SwerveModuleState state = states[i];
+                    doubles[2 * i] = state.angle.getDegrees();
+                    doubles[2 * i + 1] = state.speedMetersPerSecond;
+                }
+            }
+
+            return doubles;
+        });
+    }
+
+    @Override
+    public void periodic() {
+        state = swerve.getState();
+        field.setRobotPose(state.Pose);
+
+        // NOTE This was taken from the generated project, unsure if it is needed
+        // trySettingPerspective();
+    }
+
+    private void trySettingPerspective() {
+        if (!hasSetPerspective || DriverStation.isDisabled()) {
+            DriverStation.getAlliance().ifPresent(allianceColor -> {
+                swerve.setOperatorPerspectiveForward(
+                        allianceColor == DriverStation.Alliance.Red
+                                ? Rotation2d.k180deg
+                                : Rotation2d.kZero
+                );
+                hasSetPerspective = true;
+            });
+        }
+    }
+
+    public Pose2d getPose() {
+        return state.Pose;
+    }
+
+    public SysIdRoutine createDriveRoutine() {
+        return DriveFactory.createDriveRoutine(swerve, this);
+    }
+
+    public SysIdRoutine createSteerRoutine() {
+        return DriveFactory.createSteerRoutine(swerve, this);
+    }
+
+    public SysIdRoutine createRotationRoutine() {
+        return DriveFactory.createRotationRoutine(swerve, this);
+    }
+
+    public Command sysIdQuasistatic(
+        SysIdRoutine routine,
+        SysIdRoutine.Direction direction
+    ) {
+        return routine.quasistatic(direction);
+    }
+
+    public Command sysIdDynamic(
+        SysIdRoutine routine,
+        SysIdRoutine.Direction direction
+    ) {
+        return routine.dynamic(direction);
+    }
+
+    public Command drive(Supplier<ChassisSpeeds> fieldSpeedsSupplier) {
+        // TODO Make factory for requests
+        SwerveRequest.FieldCentric request = new SwerveRequest.FieldCentric();
+
+        return run(() -> {
+            ChassisSpeeds fieldSpeeds = fieldSpeedsSupplier.get();
+            swerve.setControl(
+                request
+                    .withVelocityX(fieldSpeeds.vxMetersPerSecond)
+                    .withVelocityY(fieldSpeeds.vyMetersPerSecond)
+                    .withRotationalRate(fieldSpeeds.omegaRadiansPerSecond)
+            );
+        });
+    }
+
+    public Command driveFacing(
+        Supplier<ChassisSpeeds> fieldSpeedsSupplier,
+        Supplier<Rotation2d> directionSupplier
+    ) {
+        // TODO Make factory for requests
+        SwerveRequest.FieldCentricFacingAngle request =
+            new SwerveRequest.FieldCentricFacingAngle();
+
+        return run(() -> {
+            ChassisSpeeds fieldSpeeds = fieldSpeedsSupplier.get();
+            Rotation2d direction = directionSupplier.get();
+            swerve.setControl(
+                request
+                    .withVelocityX(fieldSpeeds.vxMetersPerSecond)
+                    .withVelocityY(fieldSpeeds.vyMetersPerSecond)
+                    .withTargetDirection(direction)
+            );
+        });
+    }
+}

--- a/src/main/java/frc/robot/drive/DriveFactory.java
+++ b/src/main/java/frc/robot/drive/DriveFactory.java
@@ -1,0 +1,118 @@
+package frc.robot.drive;
+
+import com.ctre.phoenix6.SignalLogger;
+import com.ctre.phoenix6.swerve.SwerveRequest;
+import edu.wpi.first.wpilibj2.command.sysid.SysIdRoutine;
+import frc.lib.Subsystem;
+import frc.lib.swerves.IdealSwerveSim;
+import frc.lib.swerves.PhoenixSwerve;
+import frc.lib.swerves.SwerveOutput;
+
+import static edu.wpi.first.units.Units.Second;
+import static edu.wpi.first.units.Units.Volts;
+
+public class DriveFactory {
+
+    public static SwerveOutput createSwerve() {
+        return new IdealSwerveSim();
+    }
+
+    protected static SysIdRoutine createDriveRoutine(
+        SwerveOutput swerve,
+        Subsystem subsystem
+    ) {
+        SwerveRequest.SysIdSwerveTranslation m_translationCharacterization =
+            new SwerveRequest.SysIdSwerveTranslation();
+
+        return new SysIdRoutine(
+            new SysIdRoutine.Config(
+                null, // Use default ramp rate (1 V/s)
+                Volts.of(4), // Reduce dynamic step voltage to 4 V to prevent brownout
+                null, // Use default timeout (10 s)
+                // Log state with SignalLogger class
+                state ->
+                    SignalLogger.writeString(
+                        "SysIdTranslation_State",
+                        state.toString()
+                    )
+            ),
+            new SysIdRoutine.Mechanism(
+                output ->
+                    swerve.setControl(
+                        m_translationCharacterization.withVolts(output)
+                    ),
+                null,
+                subsystem
+            )
+        );
+    }
+
+    protected static SysIdRoutine createSteerRoutine(
+        SwerveOutput swerve,
+        Subsystem subsystem
+    ) {
+        SwerveRequest.SysIdSwerveSteerGains m_steerCharacterization =
+            new SwerveRequest.SysIdSwerveSteerGains();
+
+        return new SysIdRoutine(
+            new SysIdRoutine.Config(
+                null, // Use default ramp rate (1 V/s)
+                Volts.of(7), // Use dynamic voltage of 7 V
+                null, // Use default timeout (10 s)
+                // Log state with SignalLogger class
+                state ->
+                    SignalLogger.writeString(
+                        "SysIdSteer_State",
+                        state.toString()
+                    )
+            ),
+            new SysIdRoutine.Mechanism(
+                volts ->
+                    swerve.setControl(m_steerCharacterization.withVolts(volts)),
+                null,
+                subsystem
+            )
+        );
+    }
+
+    protected static SysIdRoutine createRotationRoutine(
+        SwerveOutput swerve,
+        Subsystem subsystem
+    ) {
+        SwerveRequest.SysIdSwerveRotation m_rotationCharacterization =
+            new SwerveRequest.SysIdSwerveRotation();
+
+        return new SysIdRoutine(
+            new SysIdRoutine.Config(
+                /* This is in radians per second², but SysId only supports "volts per second" */
+                Volts.of(Math.PI / 6).per(Second),
+                /* This is in radians per second, but SysId only supports "volts" */
+                Volts.of(Math.PI),
+                null, // Use default timeout (10 s)
+                // Log state with SignalLogger class
+                state ->
+                    SignalLogger.writeString(
+                        "SysIdRotation_State",
+                        state.toString()
+                    )
+            ),
+            new SysIdRoutine.Mechanism(
+                output -> {
+                    /* output is actually radians per second, but SysId only supports "volts" */
+                    swerve.setControl(
+                        m_rotationCharacterization.withRotationalRate(
+                            output.in(Volts)
+                        )
+                    );
+                    /* also log the requested output for SysId */
+                    SignalLogger.writeDouble(
+                        "Rotational_Rate",
+                        output.in(Volts)
+                    );
+                },
+                null,
+                subsystem
+            )
+        );
+    }
+}

--- a/src/main/java/frc/robot/drive/DriveFactory.java
+++ b/src/main/java/frc/robot/drive/DriveFactory.java
@@ -1,118 +1,74 @@
 package frc.robot.drive;
 
+import static edu.wpi.first.units.Units.Second;
+import static edu.wpi.first.units.Units.Volts;
+
 import com.ctre.phoenix6.SignalLogger;
 import com.ctre.phoenix6.swerve.SwerveRequest;
 import edu.wpi.first.wpilibj2.command.sysid.SysIdRoutine;
 import frc.lib.Subsystem;
 import frc.lib.swerves.IdealSwerveSim;
-import frc.lib.swerves.PhoenixSwerve;
 import frc.lib.swerves.SwerveOutput;
-
-import static edu.wpi.first.units.Units.Second;
-import static edu.wpi.first.units.Units.Volts;
 
 public class DriveFactory {
 
-    public static SwerveOutput createSwerve() {
-        return new IdealSwerveSim();
-    }
+  public static SwerveOutput createSwerve() {
+    return new IdealSwerveSim();
+  }
 
-    protected static SysIdRoutine createDriveRoutine(
-        SwerveOutput swerve,
-        Subsystem subsystem
-    ) {
-        SwerveRequest.SysIdSwerveTranslation m_translationCharacterization =
-            new SwerveRequest.SysIdSwerveTranslation();
+  protected static SysIdRoutine createDriveRoutine(SwerveOutput swerve, Subsystem subsystem) {
+    SwerveRequest.SysIdSwerveTranslation m_translationCharacterization =
+        new SwerveRequest.SysIdSwerveTranslation();
 
-        return new SysIdRoutine(
-            new SysIdRoutine.Config(
-                null, // Use default ramp rate (1 V/s)
-                Volts.of(4), // Reduce dynamic step voltage to 4 V to prevent brownout
-                null, // Use default timeout (10 s)
-                // Log state with SignalLogger class
-                state ->
-                    SignalLogger.writeString(
-                        "SysIdTranslation_State",
-                        state.toString()
-                    )
-            ),
-            new SysIdRoutine.Mechanism(
-                output ->
-                    swerve.setControl(
-                        m_translationCharacterization.withVolts(output)
-                    ),
-                null,
-                subsystem
-            )
-        );
-    }
+    return new SysIdRoutine(
+        new SysIdRoutine.Config(
+            null, // Use default ramp rate (1 V/s)
+            Volts.of(4), // Reduce dynamic step voltage to 4 V to prevent brownout
+            null, // Use default timeout (10 s)
+            // Log state with SignalLogger class
+            state -> SignalLogger.writeString("SysIdTranslation_State", state.toString())),
+        new SysIdRoutine.Mechanism(
+            output -> swerve.setControl(m_translationCharacterization.withVolts(output)),
+            null,
+            subsystem));
+  }
 
-    protected static SysIdRoutine createSteerRoutine(
-        SwerveOutput swerve,
-        Subsystem subsystem
-    ) {
-        SwerveRequest.SysIdSwerveSteerGains m_steerCharacterization =
-            new SwerveRequest.SysIdSwerveSteerGains();
+  protected static SysIdRoutine createSteerRoutine(SwerveOutput swerve, Subsystem subsystem) {
+    SwerveRequest.SysIdSwerveSteerGains m_steerCharacterization =
+        new SwerveRequest.SysIdSwerveSteerGains();
 
-        return new SysIdRoutine(
-            new SysIdRoutine.Config(
-                null, // Use default ramp rate (1 V/s)
-                Volts.of(7), // Use dynamic voltage of 7 V
-                null, // Use default timeout (10 s)
-                // Log state with SignalLogger class
-                state ->
-                    SignalLogger.writeString(
-                        "SysIdSteer_State",
-                        state.toString()
-                    )
-            ),
-            new SysIdRoutine.Mechanism(
-                volts ->
-                    swerve.setControl(m_steerCharacterization.withVolts(volts)),
-                null,
-                subsystem
-            )
-        );
-    }
+    return new SysIdRoutine(
+        new SysIdRoutine.Config(
+            null, // Use default ramp rate (1 V/s)
+            Volts.of(7), // Use dynamic voltage of 7 V
+            null, // Use default timeout (10 s)
+            // Log state with SignalLogger class
+            state -> SignalLogger.writeString("SysIdSteer_State", state.toString())),
+        new SysIdRoutine.Mechanism(
+            volts -> swerve.setControl(m_steerCharacterization.withVolts(volts)), null, subsystem));
+  }
 
-    protected static SysIdRoutine createRotationRoutine(
-        SwerveOutput swerve,
-        Subsystem subsystem
-    ) {
-        SwerveRequest.SysIdSwerveRotation m_rotationCharacterization =
-            new SwerveRequest.SysIdSwerveRotation();
+  protected static SysIdRoutine createRotationRoutine(SwerveOutput swerve, Subsystem subsystem) {
+    SwerveRequest.SysIdSwerveRotation m_rotationCharacterization =
+        new SwerveRequest.SysIdSwerveRotation();
 
-        return new SysIdRoutine(
-            new SysIdRoutine.Config(
-                /* This is in radians per second², but SysId only supports "volts per second" */
-                Volts.of(Math.PI / 6).per(Second),
-                /* This is in radians per second, but SysId only supports "volts" */
-                Volts.of(Math.PI),
-                null, // Use default timeout (10 s)
-                // Log state with SignalLogger class
-                state ->
-                    SignalLogger.writeString(
-                        "SysIdRotation_State",
-                        state.toString()
-                    )
-            ),
-            new SysIdRoutine.Mechanism(
-                output -> {
-                    /* output is actually radians per second, but SysId only supports "volts" */
-                    swerve.setControl(
-                        m_rotationCharacterization.withRotationalRate(
-                            output.in(Volts)
-                        )
-                    );
-                    /* also log the requested output for SysId */
-                    SignalLogger.writeDouble(
-                        "Rotational_Rate",
-                        output.in(Volts)
-                    );
-                },
-                null,
-                subsystem
-            )
-        );
-    }
+    return new SysIdRoutine(
+        new SysIdRoutine.Config(
+            /* This is in radians per second², but SysId only supports "volts per second" */
+            Volts.of(Math.PI / 6).per(Second),
+            /* This is in radians per second, but SysId only supports "volts" */
+            Volts.of(Math.PI),
+            null, // Use default timeout (10 s)
+            // Log state with SignalLogger class
+            state -> SignalLogger.writeString("SysIdRotation_State", state.toString())),
+        new SysIdRoutine.Mechanism(
+            output -> {
+              /* output is actually radians per second, but SysId only supports "volts" */
+              swerve.setControl(m_rotationCharacterization.withRotationalRate(output.in(Volts)));
+              /* also log the requested output for SysId */
+              SignalLogger.writeDouble("Rotational_Rate", output.in(Volts));
+            },
+            null,
+            subsystem));
+  }
 }


### PR DESCRIPTION
IdealSwerveSim implements an idealized swerve subsystem for testing during simulation. It exists to allow testing swerve functionality while isolating the behavior of other swerve implementations (namely CTRE's swerve library).