### PR TITLE
Swerve Sendable

### DIFF
--- a/simgui-ds.json
+++ b/simgui-ds.json
@@ -91,7 +91,7 @@
   ],
   "robotJoysticks": [
     {
-      "useGamepad": true
+      "guid": "Keyboard0"
     },
     {
       "guid": "78696e70757401000000000000000000",

--- a/src/main/java/frc/lib/sendables/SwerveDriveSendable.java
+++ b/src/main/java/frc/lib/sendables/SwerveDriveSendable.java
@@ -58,18 +58,18 @@ public class SwerveDriveSendable implements Sendable {
   public void initSendable(SendableBuilder builder) {
     builder.setSmartDashboardType("SwerveDrive");
 
-    builder.addDoubleProperty("Front Left Angle", () -> statesSupplier.get()[0].angle.getDegrees(), null);
+    builder.addDoubleProperty("Front Left Angle", () -> statesSupplier.get()[0].angle.getRadians(), null);
     builder.addDoubleProperty("Front Left Velocity", () -> statesSupplier.get()[0].speedMetersPerSecond, null);
 
-    builder.addDoubleProperty("Front Right Angle", () -> statesSupplier.get()[1].angle.getDegrees(), null);
+    builder.addDoubleProperty("Front Right Angle", () -> statesSupplier.get()[1].angle.getRadians(), null);
     builder.addDoubleProperty("Front Right Velocity", () -> statesSupplier.get()[1].speedMetersPerSecond, null);
 
-    builder.addDoubleProperty("Back Left Angle", () -> statesSupplier.get()[2].angle.getDegrees(), null);
+    builder.addDoubleProperty("Back Left Angle", () -> statesSupplier.get()[2].angle.getRadians(), null);
     builder.addDoubleProperty("Back Left Velocity", () -> statesSupplier.get()[2].speedMetersPerSecond, null);
 
-    builder.addDoubleProperty("Back Right Angle", () -> statesSupplier.get()[3].angle.getDegrees(), null);
+    builder.addDoubleProperty("Back Right Angle", () -> statesSupplier.get()[3].angle.getRadians(), null);
     builder.addDoubleProperty("Back Right Velocity", () -> statesSupplier.get()[3].speedMetersPerSecond, null);
 
-    builder.addDoubleProperty("Robot Angle", () -> robotAngleSupplier.get().getDegrees(), null);
+    builder.addDoubleProperty("Robot Angle", () -> robotAngleSupplier.get().getRadians(), null);
   }
 }

--- a/src/main/java/frc/lib/sendables/SwerveDriveSendable.java
+++ b/src/main/java/frc/lib/sendables/SwerveDriveSendable.java
@@ -1,14 +1,15 @@
 package frc.lib.sendables;
 
-import java.util.function.Supplier;
-
 import edu.wpi.first.math.geometry.Rotation2d;
+import edu.wpi.first.math.kinematics.SwerveModuleState;
 import edu.wpi.first.util.sendable.Sendable;
 import edu.wpi.first.util.sendable.SendableBuilder;
-import edu.wpi.first.math.kinematics.SwerveModuleState;
-import frc.robot.drive.Drive;
+import java.util.function.Supplier;
 
-/** Swerve drive state sendable that allows fancy visualization in most dashboards and simpler looking swerve logging */
+/**
+ * Swerve drive state sendable that allows fancy visualization in most dashboards and simpler
+ * looking swerve logging
+ */
 public class SwerveDriveSendable implements Sendable {
 
   /** Gets swerve module states [NW, NE, SW, SE] */
@@ -16,24 +17,25 @@ public class SwerveDriveSendable implements Sendable {
 
   /** Gets robot rotation */
   private final Supplier<Rotation2d> robotAngleSupplier;
-  
+
   /**
-   * Constructs a swerve drive state sendable given a module states supplier and robot angle supplier
-   * 
+   * Constructs a swerve drive state sendable given a module states supplier and robot angle
+   * supplier
+   *
    * @param statesSupplier module states supplier [NW, NE, SW, SE]
    * @param robotAngleSupplier robot angle supplier
    */
   public SwerveDriveSendable(
-      Supplier<SwerveModuleState[]> statesSupplier,
-      Supplier<Rotation2d> robotAngleSupplier) {
-    
+      Supplier<SwerveModuleState[]> statesSupplier, Supplier<Rotation2d> robotAngleSupplier) {
+
     this.statesSupplier = statesSupplier;
     this.robotAngleSupplier = robotAngleSupplier;
   }
 
   /**
-   * Constructs a swerve drive state sendable given 4 module state suppliers and a robot angle supplier
-   * 
+   * Constructs a swerve drive state sendable given 4 module state suppliers and a robot angle
+   * supplier
+   *
    * @param NWStateSupplier NW module state supplier
    * @param NEStateSupplier NE module state supplier
    * @param SWStateSupplier SW module state supplier
@@ -47,10 +49,16 @@ public class SwerveDriveSendable implements Sendable {
       Supplier<SwerveModuleState> SEStateSupplier,
       Supplier<Rotation2d> robotAngleSupplier) {
 
-    this.statesSupplier = () -> {
-      SwerveModuleState[] states = {NWStateSupplier.get(), NEStateSupplier.get(), SWStateSupplier.get(), SEStateSupplier.get()};
-      return states;
-    };
+    this.statesSupplier =
+        () -> {
+          SwerveModuleState[] states = {
+            NWStateSupplier.get(),
+            NEStateSupplier.get(),
+            SWStateSupplier.get(),
+            SEStateSupplier.get()
+          };
+          return states;
+        };
     this.robotAngleSupplier = robotAngleSupplier;
   }
 
@@ -58,17 +66,25 @@ public class SwerveDriveSendable implements Sendable {
   public void initSendable(SendableBuilder builder) {
     builder.setSmartDashboardType("SwerveDrive");
 
-    builder.addDoubleProperty("Front Left Angle", () -> statesSupplier.get()[0].angle.getRadians(), null);
-    builder.addDoubleProperty("Front Left Velocity", () -> statesSupplier.get()[0].speedMetersPerSecond, null);
+    builder.addDoubleProperty(
+        "Front Left Angle", () -> statesSupplier.get()[0].angle.getRadians(), null);
+    builder.addDoubleProperty(
+        "Front Left Velocity", () -> statesSupplier.get()[0].speedMetersPerSecond, null);
 
-    builder.addDoubleProperty("Front Right Angle", () -> statesSupplier.get()[1].angle.getRadians(), null);
-    builder.addDoubleProperty("Front Right Velocity", () -> statesSupplier.get()[1].speedMetersPerSecond, null);
+    builder.addDoubleProperty(
+        "Front Right Angle", () -> statesSupplier.get()[1].angle.getRadians(), null);
+    builder.addDoubleProperty(
+        "Front Right Velocity", () -> statesSupplier.get()[1].speedMetersPerSecond, null);
 
-    builder.addDoubleProperty("Back Left Angle", () -> statesSupplier.get()[2].angle.getRadians(), null);
-    builder.addDoubleProperty("Back Left Velocity", () -> statesSupplier.get()[2].speedMetersPerSecond, null);
+    builder.addDoubleProperty(
+        "Back Left Angle", () -> statesSupplier.get()[2].angle.getRadians(), null);
+    builder.addDoubleProperty(
+        "Back Left Velocity", () -> statesSupplier.get()[2].speedMetersPerSecond, null);
 
-    builder.addDoubleProperty("Back Right Angle", () -> statesSupplier.get()[3].angle.getRadians(), null);
-    builder.addDoubleProperty("Back Right Velocity", () -> statesSupplier.get()[3].speedMetersPerSecond, null);
+    builder.addDoubleProperty(
+        "Back Right Angle", () -> statesSupplier.get()[3].angle.getRadians(), null);
+    builder.addDoubleProperty(
+        "Back Right Velocity", () -> statesSupplier.get()[3].speedMetersPerSecond, null);
 
     builder.addDoubleProperty("Robot Angle", () -> robotAngleSupplier.get().getRadians(), null);
   }

--- a/src/main/java/frc/lib/sendables/SwerveDriveSendable.java
+++ b/src/main/java/frc/lib/sendables/SwerveDriveSendable.java
@@ -31,6 +31,29 @@ public class SwerveDriveSendable implements Sendable {
     this.robotAngleSupplier = robotAngleSupplier;
   }
 
+  /**
+   * Constructs a swerve drive state sendable given 4 module state suppliers and a robot angle supplier
+   * 
+   * @param NWStateSupplier NW module state supplier
+   * @param NEStateSupplier NE module state supplier
+   * @param SWStateSupplier SW module state supplier
+   * @param SEStateSupplier SE module state supplier
+   * @param robotAngleSupplier robot angle supplier
+   */
+  public SwerveDriveSendable(
+      Supplier<SwerveModuleState> NWStateSupplier,
+      Supplier<SwerveModuleState> NEStateSupplier,
+      Supplier<SwerveModuleState> SWStateSupplier,
+      Supplier<SwerveModuleState> SEStateSupplier,
+      Supplier<Rotation2d> robotAngleSupplier) {
+
+    this.statesSupplier = () -> {
+      SwerveModuleState[] states = {NWStateSupplier.get(), NEStateSupplier.get(), SWStateSupplier.get(), SEStateSupplier.get()};
+      return states;
+    };
+    this.robotAngleSupplier = robotAngleSupplier;
+  }
+
   @Override
   public void initSendable(SendableBuilder builder) {
     builder.setSmartDashboardType("SwerveDrive");

--- a/src/main/java/frc/lib/sendables/SwerveDriveSendable.java
+++ b/src/main/java/frc/lib/sendables/SwerveDriveSendable.java
@@ -1,0 +1,52 @@
+package frc.lib.sendables;
+
+import java.util.function.Supplier;
+
+import edu.wpi.first.math.geometry.Rotation2d;
+import edu.wpi.first.util.sendable.Sendable;
+import edu.wpi.first.util.sendable.SendableBuilder;
+import edu.wpi.first.math.kinematics.SwerveModuleState;
+import frc.robot.drive.Drive;
+
+/** Swerve drive state sendable that allows fancy visualization in most dashboards and simpler looking swerve logging */
+public class SwerveDriveSendable implements Sendable {
+
+  /** Gets swerve module states [NW, NE, SW, SE] */
+  private final Supplier<SwerveModuleState[]> statesSupplier;
+
+  /** Gets robot rotation */
+  private final Supplier<Rotation2d> robotAngleSupplier;
+  
+  /**
+   * Constructs a swerve drive state sendable given a module states supplier and robot angle supplier
+   * 
+   * @param statesSupplier module states supplier [NW, NE, SW, SE]
+   * @param robotAngleSupplier robot angle supplier
+   */
+  public SwerveDriveSendable(
+      Supplier<SwerveModuleState[]> statesSupplier,
+      Supplier<Rotation2d> robotAngleSupplier) {
+    
+    this.statesSupplier = statesSupplier;
+    this.robotAngleSupplier = robotAngleSupplier;
+  }
+
+  @Override
+  public void initSendable(SendableBuilder builder) {
+    builder.setSmartDashboardType("SwerveDrive");
+
+    builder.addDoubleProperty("Front Left Angle", () -> statesSupplier.get()[0].angle.getDegrees(), null);
+    builder.addDoubleProperty("Front Left Velocity", () -> statesSupplier.get()[0].speedMetersPerSecond, null);
+
+    builder.addDoubleProperty("Front Right Angle", () -> statesSupplier.get()[1].angle.getDegrees(), null);
+    builder.addDoubleProperty("Front Right Velocity", () -> statesSupplier.get()[1].speedMetersPerSecond, null);
+
+    builder.addDoubleProperty("Back Left Angle", () -> statesSupplier.get()[2].angle.getDegrees(), null);
+    builder.addDoubleProperty("Back Left Velocity", () -> statesSupplier.get()[2].speedMetersPerSecond, null);
+
+    builder.addDoubleProperty("Back Right Angle", () -> statesSupplier.get()[3].angle.getDegrees(), null);
+    builder.addDoubleProperty("Back Right Velocity", () -> statesSupplier.get()[3].speedMetersPerSecond, null);
+
+    builder.addDoubleProperty("Robot Angle", () -> robotAngleSupplier.get().getDegrees(), null);
+  }
+}

--- a/src/main/java/frc/robot/drive/Drive.java
+++ b/src/main/java/frc/robot/drive/Drive.java
@@ -5,7 +5,6 @@ import com.ctre.phoenix6.swerve.SwerveRequest;
 import edu.wpi.first.math.geometry.Pose2d;
 import edu.wpi.first.math.geometry.Rotation2d;
 import edu.wpi.first.math.kinematics.ChassisSpeeds;
-import edu.wpi.first.math.kinematics.SwerveModuleState;
 import edu.wpi.first.wpilibj.DriverStation;
 import edu.wpi.first.wpilibj.shuffleboard.Shuffleboard;
 import edu.wpi.first.wpilibj.shuffleboard.ShuffleboardTab;
@@ -39,15 +38,11 @@ public class Drive extends Subsystem {
 
     tab.add("Field", field);
     tab.add(
-      "States", 
-      new SwerveDriveSendable(
-        () -> state.ModuleStates, 
-        () -> this.getPose().getRotation()));
+        "States",
+        new SwerveDriveSendable(() -> state.ModuleStates, () -> this.getPose().getRotation()));
     tab.add(
-      "Targets",
-      new SwerveDriveSendable(
-        () -> state.ModuleTargets, 
-        () -> this.getPose().getRotation()));
+        "Targets",
+        new SwerveDriveSendable(() -> state.ModuleTargets, () -> this.getPose().getRotation()));
   }
 
   @Override

--- a/src/main/java/frc/robot/drive/Drive.java
+++ b/src/main/java/frc/robot/drive/Drive.java
@@ -37,6 +37,7 @@ public class Drive extends Subsystem {
   public void initializeTab() {
     ShuffleboardTab tab = Shuffleboard.getTab("Swerve");
 
+    tab.add("Field", field);
     tab.add(
       "States", 
       new SwerveDriveSendable(

--- a/src/main/java/frc/robot/drive/Drive.java
+++ b/src/main/java/frc/robot/drive/Drive.java
@@ -13,6 +13,7 @@ import edu.wpi.first.wpilibj.smartdashboard.Field2d;
 import edu.wpi.first.wpilibj2.command.Command;
 import edu.wpi.first.wpilibj2.command.sysid.SysIdRoutine;
 import frc.lib.Subsystem;
+import frc.lib.sendables.SwerveDriveSendable;
 import frc.lib.swerves.SwerveOutput;
 import java.util.function.Supplier;
 
@@ -36,39 +37,16 @@ public class Drive extends Subsystem {
   public void initializeTab() {
     ShuffleboardTab tab = Shuffleboard.getTab("Swerve");
 
-    tab.add(field);
-    tab.addDoubleArray(
-        "States",
-        () -> {
-          SwerveModuleState[] states = state.ModuleStates;
-          double[] doubles = new double[8];
-
-          if (states != null) {
-            for (int i = 0; i < 4; i++) {
-              SwerveModuleState state = states[i];
-              doubles[2 * i] = state.angle.getDegrees();
-              doubles[2 * i + 1] = state.speedMetersPerSecond;
-            }
-          }
-
-          return doubles;
-        });
-    tab.addDoubleArray(
-        "Targets",
-        () -> {
-          SwerveModuleState[] states = state.ModuleTargets;
-          double[] doubles = new double[8];
-
-          if (states != null) {
-            for (int i = 0; i < 4; i++) {
-              SwerveModuleState state = states[i];
-              doubles[2 * i] = state.angle.getDegrees();
-              doubles[2 * i + 1] = state.speedMetersPerSecond;
-            }
-          }
-
-          return doubles;
-        });
+    tab.add(
+      "States", 
+      new SwerveDriveSendable(
+        () -> state.ModuleStates, 
+        () -> this.getPose().getRotation()));
+    tab.add(
+      "Targets",
+      new SwerveDriveSendable(
+        () -> state.ModuleTargets, 
+        () -> this.getPose().getRotation()));
   }
 
   @Override


### PR DESCRIPTION
better logging for swerve with a swerve sendable

I don't really love calling a supplier to get an entire list of all swerve states 8 times every update but this is probably ok for now and there probably isn't much performance impact if any at all